### PR TITLE
Fixes the play button not showing in overlay layout

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/services/ScreenTextService.java
+++ b/app/src/main/java/com/guillermonegrete/tts/services/ScreenTextService.java
@@ -136,7 +136,7 @@ public class ScreenTextService extends Service {
     @Override
     public void onCreate() {
         super.onCreate();
-
+        setTheme(R.style.AppTheme);
         service_layout = View.inflate(this, R.layout.service_processtext, null);
         trash_layout = new TrashView(this);
         hasPermission = false;


### PR DESCRIPTION
Fixes #12. This was caused because the icon was using a material attribute `colorOnSurface`. Because the overlay layout is in a service it had no theme, adding the style `AppTheme` adds the missing material attributes.