### PR TITLE
bugfix #19 page number not saved

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextActivity.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextActivity.kt
@@ -120,6 +120,11 @@ class VisualizeTextActivity: AppCompatActivity() {
         setUpSeekBar()
     }
 
+    override fun onPause() {
+        super.onPause()
+        viewModel.saveBookData()
+    }
+
     /**
      * Handle scaling in text view with selectable text and clickable spans. Intercept touch event if is scaling.
      *
@@ -342,7 +347,6 @@ class VisualizeTextActivity: AppCompatActivity() {
     private fun setBackgroundColor(theme: BrightnessTheme){
         if(theme != brightnessTheme) {
             saveBrightnessPreference(theme.value)
-            viewModel.onFinish()
             finish()
             startActivity(intent)
         }

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModel.kt
@@ -30,8 +30,6 @@ class VisualizeTextViewModel @ViewModelInject constructor(
     private var firstLoad = true
     private var leftSwipe = false
 
-    private var cleared = false
-
     private var text = ""
     var currentPage = -1
     var currentChapter = -1
@@ -291,18 +289,11 @@ class VisualizeTextViewModel @ViewModelInject constructor(
         _pages.value = Event(mutablePages)
     }
 
-    override fun onCleared() {
-        if(!cleared) onFinish()
-        super.onCleared()
-    }
-
     /**
-     * Sometimes is necessary to wrap up before onCleared is called (e.g. when changing theme)
-     * This function can be called before activity/fragment is destroyed.
+     * Persists the book data when the user stops interacting with the app (should be called when onPaused())
      */
-    fun onFinish(date: Calendar = Calendar.getInstance(), folderPath: String = uuid) {
+    fun saveBookData(date: Calendar = Calendar.getInstance(), folderPath: String = uuid) {
         saveBookFileData(date, folderPath)
-        cleared = true
     }
 
     private fun saveBookFileData(date: Calendar, path: String){

--- a/app/src/test/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModelTest.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModelTest.kt
@@ -282,7 +282,7 @@ class VisualizeTextViewModelTest {
 
         val lastReadDate = Calendar.getInstance()
         val uuid = "random"
-        viewModel.onFinish(lastReadDate, uuid)
+        viewModel.saveBookData(lastReadDate, uuid)
 
         val sumPreviousChars = sumCharacters(3, initialPage)
 
@@ -325,7 +325,7 @@ class VisualizeTextViewModelTest {
 
         val lastReadDate = Calendar.getInstance()
         val uuid = "random"
-        viewModel.onFinish(lastReadDate, uuid)
+        viewModel.saveBookData(lastReadDate, uuid)
 
         mainCoroutineRule.resumeDispatcher()
 
@@ -350,7 +350,7 @@ class VisualizeTextViewModelTest {
         // Swipe to right
         viewModel.swipeChapterRight()
         val lastReadDate = Calendar.getInstance()
-        viewModel.onFinish(lastReadDate)
+        viewModel.saveBookData(lastReadDate)
 
         val sumPreviousChars = sumCharacters(3, 0)
 
@@ -385,7 +385,7 @@ class VisualizeTextViewModelTest {
 
         val lastReadDate = Calendar.getInstance()
         val uuid = "random"
-        viewModel.onFinish(lastReadDate, uuid)
+        viewModel.saveBookData(lastReadDate, uuid)
 
         val expectedFile = BookFile(
             book.uri,
@@ -412,7 +412,7 @@ class VisualizeTextViewModelTest {
         parse_book(DEFAULT_BOOK)
 
         val lastReadDate = Calendar.getInstance()
-        viewModel.onFinish(lastReadDate)
+        viewModel.saveBookData(lastReadDate)
 
         assertEquals(1, fileRepository.filesServiceData.values.size)
     }


### PR DESCRIPTION
Fixes #19. Sometimes the number of the page the user was viewing was not saved when the app was destroyed (either manually or by the system). This issue was caused by saving the data on `onCleared()` of `ViewModel`, which is not always called. This was fixed by saving the data on the method `onPause()` as recommended by the docs.