### PR TITLE
Bugfix/#33 constant page text

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextActivity.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextActivity.kt
@@ -12,8 +12,6 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.cardview.widget.CardView
-import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.content.edit
 import androidx.core.view.*
 import androidx.viewpager2.widget.ViewPager2
@@ -33,7 +31,6 @@ class VisualizeTextActivity: AppCompatActivity() {
     private val viewModel: VisualizeTextViewModel by viewModels()
 
     private lateinit var viewPager: ViewPager2
-    private lateinit var rootConstraintLayout: ConstraintLayout
     private lateinit var progressBar: ProgressBar
     private lateinit var pagesSeekBar: SeekBar
     private lateinit var currentPageLabel: TextView
@@ -49,9 +46,6 @@ class VisualizeTextActivity: AppCompatActivity() {
     private var pageItemView: View? = null
 
     private lateinit var pagesAdapter: VisualizerAdapter
-
-    private val expandedConstraintSet = ConstraintSet()
-    private val contractedConstraintSet = ConstraintSet()
 
     @Inject lateinit var preferences: SharedPreferences
     @Inject lateinit var brightnessTheme: BrightnessTheme
@@ -75,11 +69,6 @@ class VisualizeTextActivity: AppCompatActivity() {
         bottomText = findViewById(R.id.page_bottom_text_view)
         bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet)
         translationProgress = findViewById(R.id.page_translation_progress)
-
-        rootConstraintLayout = findViewById(R.id.visualizer_root_layout)
-
-        contractedConstraintSet.clone(rootConstraintLayout)
-        expandedConstraintSet.clone(this, R.layout.activity_visualize_text_expanded)
 
         currentPageLabel = findViewById(R.id.reader_current_page)
         currentChapterLabel = findViewById(R.id.reader_current_chapter)
@@ -224,7 +213,6 @@ class VisualizeTextActivity: AppCompatActivity() {
             pages.observe(this@VisualizeTextActivity, EventObserver {
                 updateCurrentChapterLabel()
                 setUpPagerAndIndexLabel(it)
-                updateScreenMode()
             })
 
             book.observe(this@VisualizeTextActivity, {
@@ -244,7 +232,6 @@ class VisualizeTextActivity: AppCompatActivity() {
                     View.VISIBLE
                 }
                 showTOCBtn.visibility = tocVisibility
-                contractedConstraintSet.setVisibility(R.id.show_toc_btn, tocVisibility)
             })
 
             translatedPageIndex.observe(this@VisualizeTextActivity, EventObserver {
@@ -295,15 +282,6 @@ class VisualizeTextActivity: AppCompatActivity() {
         // Subtract 1 because seek bar is zero based numbering
         pagesSeekBar.max = pages.size - 1
         pagesSeekBar.progress = position
-    }
-
-    private fun updateScreenMode() {
-        if(viewModel.fullScreen) {
-            hideSystemUi()
-            expandedConstraintSet.applyTo(rootConstraintLayout)
-
-            viewPager.post { setBottomSheetPeekHeight() }
-        }
     }
 
     private fun showSettingsPopUp(view: View) {

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextActivity.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextActivity.kt
@@ -126,7 +126,7 @@ class VisualizeTextActivity: AppCompatActivity() {
     }
 
     /**
-     * Handle scaling in text view with selectable text and clickable spans. Intercept touch event if is scaling.
+     * Handle scaling in text view with selectable text and clickable spans. Intercept touch event if it's scaling.
      *
      * Inspired by: https://stackoverflow.com/a/5369880/10244759
      */
@@ -161,7 +161,7 @@ class VisualizeTextActivity: AppCompatActivity() {
             }
         }
 
-        // When scaling don't handle other events, this avoids unexpected click and changes of page
+        // When scaling don't handle other events, this avoids unexpected clicks and changes of page
         return if(scaleInProgress) true else super.dispatchTouchEvent(ev)
     }
 
@@ -496,6 +496,19 @@ class VisualizeTextActivity: AppCompatActivity() {
             viewPager.isUserInputEnabled = true
             textCardView.scaleX = 1f
             textCardView.scaleY = 1f
+
+            detector ?: return
+            val factor = detector.scaleFactor
+
+            // Check if it should toggle off full screen mode
+            if(viewModel.fullScreen && factor < 1.0f){
+                val lastWidth = screenWidth * factor
+                val middleWidth = cardWidth + (screenWidth - cardWidth) / 2f
+                if(lastWidth < middleWidth){
+                    toggleImmersiveMode()
+                    initialWidth = cardWidth
+                }
+            }
         }
 
         override fun onScale(detector: ScaleGestureDetector?): Boolean {
@@ -518,12 +531,6 @@ class VisualizeTextActivity: AppCompatActivity() {
                     toggleImmersiveMode()
                     pinchDetected = true
                     initialWidth = screenWidth
-                    return true
-                }
-                if(detector.scaleFactor < PINCH_LOWER_LIMIT && fullScreen){
-                    toggleImmersiveMode()
-                    pinchDetected = true
-                    initialWidth = cardWidth
                     return true
                 }
             }
@@ -623,6 +630,5 @@ class VisualizeTextActivity: AppCompatActivity() {
         const val FILE_ID = "fileId"
 
         const val PINCH_UPPER_LIMIT = 1.15f
-        const val PINCH_LOWER_LIMIT = 0.8f
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextActivity.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextActivity.kt
@@ -54,6 +54,8 @@ class VisualizeTextActivity: AppCompatActivity() {
 
     private lateinit var scaleDetector: ScaleGestureDetector
 
+    private var cardWidth = 0
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setPreferenceTheme()
@@ -63,6 +65,7 @@ class VisualizeTextActivity: AppCompatActivity() {
         pagesSeekBar = findViewById(R.id.pages_seekBar)
 
         textCardView = findViewById(R.id.text_reader_card_view)
+        setUpCardViewDimensions()
 
         // Bottom sheet
         bottomSheet = findViewById(R.id.visualizer_bottom_sheet)
@@ -107,6 +110,23 @@ class VisualizeTextActivity: AppCompatActivity() {
 
         setUIChangesListener()
         setUpSeekBar()
+    }
+
+    /**
+     *  Changes the dimensions of the card to have the same aspect ratio as the screen.
+     */
+    private fun setUpCardViewDimensions() {
+        val metrics = resources.displayMetrics
+        val ratio = metrics.heightPixels.toFloat() / metrics.widthPixels.toFloat()
+
+        val cardParams = textCardView.layoutParams
+
+        textCardView.post {
+            cardWidth = (textCardView.height / ratio).toInt()
+            cardParams.width = cardWidth
+            cardParams.height = textCardView.height
+            textCardView.layoutParams = cardParams
+        }
     }
 
     override fun onPause() {
@@ -451,20 +471,12 @@ class VisualizeTextActivity: AppCompatActivity() {
     inner class PinchListener: ScaleGestureDetector.OnScaleGestureListener{
 
         private var pinchDetected = false
-        private var cardWidth = 0
 
         private val screenWidth = this@VisualizeTextActivity.resources.displayMetrics.widthPixels
 
-        // Ratio between the width of the card and the screen
-        private var ratio = 1f
+        private val ratio
+            get() = screenWidth.toFloat() / cardWidth
         private var scale = 1f
-
-        init {
-            textCardView.doOnPreDraw {
-                cardWidth = textCardView.width
-                ratio = screenWidth.toFloat() / cardWidth.toFloat()
-            }
-        }
 
         override fun onScaleBegin(detector: ScaleGestureDetector?): Boolean {
             viewPager.isUserInputEnabled = false

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModel.kt
@@ -55,6 +55,10 @@ class VisualizeTextViewModel @ViewModelInject constructor(
 
     private var currentPages = listOf<CharSequence>()
     private val _pages = MutableLiveData<Event<List<CharSequence>>>()
+    /**
+     * Called every time pages have been processed, called when visualizer starts and
+     * when switching between chapters.
+     */
     val pages: LiveData<Event<List<CharSequence>>>
         get() = _pages
 

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizerAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizerAdapter.kt
@@ -6,7 +6,6 @@ import android.text.method.LinkMovementMethod
 import android.view.*
 import android.widget.LinearLayout
 import android.widget.TextView
-import androidx.core.widget.TextViewCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.guillermonegrete.tts.R
 import com.guillermonegrete.tts.utils.dpToPixel
@@ -20,8 +19,6 @@ class VisualizerAdapter(
     private val measuringPage: Boolean = false
 ): RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
-    private val isExpanded
-        get() = viewModel.fullScreen
     val hasBottomSheet
         get() = viewModel.hasBottomSheet
 
@@ -39,7 +36,7 @@ class VisualizerAdapter(
         val layout = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
         return when(viewType){
             R.layout.visualizer_split_page_item -> SplitPageViewHolder(layout)
-            else -> if(measuringPage) ViewHolder(layout) else PageViewHolder(isExpanded, layout)
+            else -> if(measuringPage) ViewHolder(layout) else PageViewHolder(layout)
         }
     }
 
@@ -70,7 +67,7 @@ class VisualizerAdapter(
     }
 
     open inner class ViewHolder(view: View): RecyclerView.ViewHolder(view) {
-        protected val pageTextView: TextView = view.findViewById(R.id.page_text_view)
+        private val pageTextView: TextView = view.findViewById(R.id.page_text_view)
 
         private val actionModeCallback = PageActionModeCallback(pageTextView, showTextDialog)
 
@@ -118,12 +115,7 @@ class VisualizerAdapter(
 
     }
 
-    inner class PageViewHolder(isExpanded: Boolean, view: View): ViewHolder(view){
-
-        init {
-            val autoSizeType = if(isExpanded) TextViewCompat.AUTO_SIZE_TEXT_TYPE_UNIFORM else TextViewCompat.AUTO_SIZE_TEXT_TYPE_NONE
-            TextViewCompat.setAutoSizeTextTypeWithDefaults(pageTextView, autoSizeType)
-        }
+    inner class PageViewHolder(view: View): ViewHolder(view){
 
         fun bind(text: CharSequence){
             setPageText(text)

--- a/app/src/main/res/layout/activity_visualize_text.xml
+++ b/app/src/main/res/layout/activity_visualize_text.xml
@@ -17,19 +17,18 @@
         tools:text="Chapter: 1 of 5" />
 
     <androidx.cardview.widget.CardView
+        android:id="@+id/text_reader_card_view"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:id="@+id/text_reader_card_view"
-        app:layout_constraintBottom_toTopOf="@+id/reader_current_page"
+        android:layout_marginStart="32dp"
+        android:layout_marginEnd="32dp"
+        android:elevation="4dp"
+        app:cardBackgroundColor="?attr/cardBackground"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/reader_current_chapter"
-        android:layout_marginStart="32dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="32dp"
-        android:layout_marginBottom="16dp"
-        app:cardBackgroundColor="?attr/cardBackground"
-        android:elevation="4dp">
+        app:layout_constraintTop_toTopOf="parent">
+
         <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -43,9 +42,9 @@
                 android:id="@+id/visualizer_bottom_sheet"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
-                app:behavior_peekHeight="60dp"
                 android:visibility="gone"
+                app:behavior_peekHeight="60dp"
+                app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
                 tools:visibility="visible">
 
                 <View
@@ -83,22 +82,22 @@
                     app:iconTint="?iconTintColor"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="@id/peek_view"
-                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.Button.Circle"/>
+                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.Button.Circle" />
 
                 <TextView
                     android:id="@+id/page_bottom_text_view"
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
+                    android:background="?cardBackground"
                     android:paddingStart="40dp"
                     android:paddingEnd="40dp"
                     android:paddingBottom="8dp"
                     android:textAppearance="@style/TextAppearance.AppCompat.Large"
-                    android:background="?cardBackground"
+                    app:autoSizeMaxTextSize="30sp"
+                    app:autoSizeTextType="uniform"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/page_translate_btn"
-                    app:autoSizeTextType="uniform"
-                    app:autoSizeMaxTextSize="30sp"
-                    tools:text="Real content to display"/>
+                    tools:text="Real content to display" />
 
                 <androidx.constraintlayout.widget.Guideline
                     android:id="@+id/guideline_mid_height"
@@ -112,12 +111,12 @@
                     style="@android:style/Widget.Material.ProgressBar"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:visibility="invisible"
                     app:layout_constraintBottom_toBottomOf="@+id/page_bottom_text_view"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/peek_view"
-                    android:visibility="invisible"
-                    tools:visibility="visible"/>
+                    tools:visibility="visible" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
     </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/visualizer_split_page_item.xml
+++ b/app/src/main/res/layout/visualizer_split_page_item.xml
@@ -15,6 +15,7 @@
         android:layout_weight="0.5"
         android:textIsSelectable="true"
         app:autoSizeTextType="uniform">
+<!--        app:autoSizeMaxTextSize="@dimen/text_size_large"-->
         <requestFocus />
     </TextView>
     <View

--- a/app/src/main/res/layout/visualizer_split_page_item.xml
+++ b/app/src/main/res/layout/visualizer_split_page_item.xml
@@ -14,8 +14,9 @@
         android:layout_marginStart="40dp"
         android:layout_weight="0.5"
         android:textIsSelectable="true"
-        app:autoSizeTextType="uniform">
-<!--        app:autoSizeMaxTextSize="@dimen/text_size_large"-->
+        app:autoSizeTextType="uniform"
+        app:autoSizeMaxTextSize="@dimen/text_size_large">
+<!--    Set large size as max, we only want the text to shrink -->
         <requestFocus />
     </TextView>
     <View


### PR DESCRIPTION
Fixes #33 and fixes #32. The expanded view is done using `scaleX` and `scaleY` instead of using `ConstraintSet`. This avoids the text changing when switching between full screen and normal. This also fixed the issue with the text of the last page increasing because it doesn't use `AutoSizeText` anymore, this only fixed the normal page. The split pages still use auto size, to fix this issue a maximum size was set equivalent to the default size, this prevents the text from increasing but still allows it to shrink if necessary.