### PR TITLE
Pr/word repo dependencies

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/data/source/WordRepository.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/WordRepository.java
@@ -22,7 +22,6 @@ import static com.google.android.gms.common.internal.Preconditions.checkNotNull;
 @Singleton
 public class WordRepository implements WordRepositorySource {
 
-    private final WordDataSource remoteTranslatorSource;
     private final WordDataSource mWordLocalDataSource;
 
     private final TranslationSource translationSource;
@@ -31,10 +30,8 @@ public class WordRepository implements WordRepositorySource {
 
 
     @Inject
-    public WordRepository(@ApplicationModule.RemoteTranslationDataSource WordDataSource remoteTranslatorSource,
-                          @ApplicationModule.WordsLocalDataSource WordDataSource wordLocalDataSource,
-                          @NonNull TranslationSource translationSource){
-        this.remoteTranslatorSource = checkNotNull(remoteTranslatorSource);
+    public WordRepository(@ApplicationModule.WordsLocalDataSource WordDataSource wordLocalDataSource,
+                          @ApplicationModule.RemoteTranslationSource @NonNull TranslationSource translationSource){
         mWordLocalDataSource = checkNotNull(wordLocalDataSource);
         this.translationSource = translationSource;
 

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/WordRepository.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/WordRepository.java
@@ -57,11 +57,6 @@ public class WordRepository implements WordRepositorySource {
     }
 
     @Override
-    public void getWordLanguageInfo(String wordText, GetWordRepositoryCallback callback) {
-        getWordLanguageInfo(wordText, "auto", "en", callback);
-    }
-
-    @Override
     public void getWordLanguageInfo(final @NonNull String wordText, final @NonNull String languageFrom, final @NonNull String languageTo, final @NonNull GetWordRepositoryCallback callback) {
         mWordLocalDataSource.getWordLanguageInfo(wordText, languageFrom, languageTo, new WordDataSource.GetWordCallback(){
 
@@ -86,19 +81,12 @@ public class WordRepository implements WordRepositorySource {
 
     @Override
     public void getLanguageAndTranslation(@NonNull String text, @NonNull String languageFrom, @NonNull String languageTo, final @NonNull GetTranslationCallback callback) {
-        remoteTranslatorSource.getWordLanguageInfo(text, languageFrom , languageTo, new WordDataSource.GetWordCallback() {
-            @Override
-            public void onWordLoaded(Words word) {
-                callback.onTranslationAndLanguage(word);
-                cachedWords.put(text, word);
-            }
-
-            @Override
-            public void onDataNotAvailable() {
-                callback.onDataNotAvailable();
-            }
-        });
-
+        try{
+            Translation translation = translationSource.getTranslation(text, languageFrom, languageTo);
+            callback.onTranslationAndLanguage(new Words(text, translation.getSrc(), translation.getTranslatedText()));
+        }catch (Exception e){
+            callback.onDataNotAvailable();
+        }
     }
 
     @Override
@@ -141,7 +129,7 @@ public class WordRepository implements WordRepositorySource {
             return;
         }
 
-        remoteTranslatorSource.getWordLanguageInfo(wordText, languageFrom, languageTo, new WordDataSource.GetWordCallback() {
+/*        remoteTranslatorSource.getWordLanguageInfo(wordText, languageFrom, languageTo, new WordDataSource.GetWordCallback() {
 
             @Override
             public void onWordLoaded(Words word) {
@@ -153,6 +141,14 @@ public class WordRepository implements WordRepositorySource {
             public void onDataNotAvailable() {
                 callback.onDataNotAvailable(new Words(wordText, "un", "un"));
             }
-        });
+        });*/
+        try{
+            Translation translation = translationSource.getTranslation(wordText, languageFrom, languageTo);
+            Words word = new Words(wordText, translation.getSrc(), translation.getTranslatedText());
+            callback.onRemoteWordLoaded(word);
+            cachedWords.put(wordText, word);
+        }catch (Exception e){
+            callback.onDataNotAvailable(new Words(wordText, "un", "un"));
+        }
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/WordRepositorySource.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/WordRepositorySource.java
@@ -34,8 +34,6 @@ public interface WordRepositorySource {
 
     List<String> getLanguagesISO();
 
-    void getWordLanguageInfo(String wordText, GetWordRepositoryCallback callback);
-
     void getWordLanguageInfo(@NonNull String wordText, @NonNull String languageFrom, @NonNull String languageTo, @NonNull GetWordRepositoryCallback callback);
 
     void getLanguageAndTranslation(@NonNull String text, @NonNull GetTranslationCallback callback);

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/remote/GooglePublicSource.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/remote/GooglePublicSource.kt
@@ -1,77 +1,16 @@
 package com.guillermonegrete.tts.data.source.remote
 
 import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import com.guillermonegrete.tts.data.Segment
 import com.guillermonegrete.tts.data.Translation
 import com.guillermonegrete.tts.data.source.TranslationSource
-import com.guillermonegrete.tts.data.source.WordDataSource
 import com.guillermonegrete.tts.db.Words
 import retrofit2.*
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class GooglePublicSource @Inject constructor(private val googlePublicAPI: GooglePublicAPI): WordDataSource, TranslationSource {
-
-    /**
-     *  These three functions should not be used for this implementation
-     */
-    override fun getWords(): MutableList<Words> = mutableListOf()
-
-    override fun getLanguagesISO(): MutableList<String> = mutableListOf()
-
-    override fun getWordsStream(): LiveData<MutableList<Words>> = MutableLiveData()
-
-    override fun insertWords(vararg words: Words?) {}
-
-    override fun deleteWords(vararg words: Words?) {}
-
-    override fun getWordLanguageInfo(
-        wordText: String?,
-        languageFrom: String?,
-        languageTo: String?,
-        callback: WordDataSource.GetWordCallback?
-    ) {
-        if (wordText != null && languageTo!= null && languageFrom != null) {
-
-            val rawLanguageFrom = if(languageFrom == "he") "iw" else languageFrom
-
-            googlePublicAPI.getWord(wordText, rawLanguageFrom, languageTo).enqueue(object : Callback<GoogleTranslateResponse>{
-                override fun onFailure(call: Call<GoogleTranslateResponse>, t: Throwable) {
-                    callback?.onDataNotAvailable()
-                }
-
-                override fun onResponse(call: Call<GoogleTranslateResponse>, response: Response<GoogleTranslateResponse>) {
-
-                    val body = response.body()
-                    if(response.isSuccessful && body != null){
-                        val parsedWord = processText(body, wordText)
-                        callback?.onWordLoaded(parsedWord)
-                    }else{
-                        callback?.onDataNotAvailable()
-                    }
-                }
-
-            })
-        }
-    }
-
-    override fun getWordLanguageInfo(
-        wordText: String,
-        languageFrom: String,
-        languageTo: String
-    ): Words {
-        val rawLanguageFrom = if(languageFrom == "he") "iw" else languageFrom
-
-        val response = googlePublicAPI.getWord(wordText, rawLanguageFrom, languageTo).execute()
-        val responseBody = response.body()
-
-        if(!response.isSuccessful || responseBody == null) throw HttpException(response)
-
-        return processText(responseBody, wordText)
-    }
+class GooglePublicSource @Inject constructor(private val googlePublicAPI: GooglePublicAPI): TranslationSource {
 
     override fun getTranslation(
         text: String,

--- a/app/src/main/java/com/guillermonegrete/tts/di/ApplicationModule.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/di/ApplicationModule.kt
@@ -55,7 +55,7 @@ object ApplicationModule {
 
     @Qualifier
     @Retention(AnnotationRetention.RUNTIME)
-    annotation class RemoteTranslationDataSource
+    annotation class RemoteTranslationSource
 
     @Qualifier
     @Retention(AnnotationRetention.RUNTIME)
@@ -113,13 +113,13 @@ object ApplicationModule {
     @Provides
     fun provideFileDAO(database: FilesDatabase): FileDAO = database.fileDao()
 
-    @RemoteTranslationDataSource
+    @RemoteTranslationSource
     @Provides
     fun provideRemoteTranslationSource(
         type: TranslatorType,
-        map: @JvmSuppressWildcards Map<TranslatorType, WordDataSource>,
+        map: @JvmSuppressWildcards Map<TranslatorType, TranslationSource>,
         defaultSource: GooglePublicSource
-    ): WordDataSource{
+    ): TranslationSource{
         return map[type] ?: defaultSource
     }
 
@@ -207,7 +207,7 @@ class GoogleSourceModule{
     @Singleton
     @IntoMap
     @TranslatorEnumKey(TranslatorType.GOOGLE_PUBLIC)
-    fun provideGooglePublicSource(api: GooglePublicAPI): WordDataSource = GooglePublicSource(api)
+    fun provideGooglePublicSource(api: GooglePublicAPI): TranslationSource = GooglePublicSource(api)
 }
 
 @InstallIn(ApplicationComponent::class)

--- a/app/src/main/java/com/guillermonegrete/tts/main/MainTTSPresenter.java
+++ b/app/src/main/java/com/guillermonegrete/tts/main/MainTTSPresenter.java
@@ -45,17 +45,17 @@ public class MainTTSPresenter extends AbstractPresenter implements MainTTSContra
 
             // TODO this request should be done in a background thread
             if(lang == null) {
-                wordRepository.getLanguageAndTranslation(text, new WordRepositorySource.GetTranslationCallback() {
+                executorService.submit(() -> wordRepository.getLanguageAndTranslation(text, new WordRepositorySource.GetTranslationCallback() {
                     @Override
                     public void onTranslationAndLanguage(Words word) {
                         String language = word.lang;
                         tts.initializeTTS(language, ttsListener);
-                        view.showDetectedLanguage(language);
+                        mMainThread.post(() -> view.showDetectedLanguage(language));
                     }
 
                     @Override
                     public void onDataNotAvailable() {}
-                });
+                }));
             } else {
                 tts.initializeTTS(lang, ttsListener);
             }

--- a/app/src/main/java/com/guillermonegrete/tts/main/domain/interactors/GetLangAndTranslation.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/main/domain/interactors/GetLangAndTranslation.kt
@@ -36,7 +36,7 @@ class GetLangAndTranslation @Inject constructor(
         this.languageFrom = languageFrom
         this.languageTo = languageTo
         this.callback = callback
-        run()
+        execute()
     }
 
     operator fun invoke(
@@ -48,19 +48,13 @@ class GetLangAndTranslation @Inject constructor(
     }
 
     override fun run() {
-        wordRepository.getLanguageAndTranslation(
-            text,
-            languageFrom,
-            languageTo,
-            object : WordRepositorySource.GetTranslationCallback{
-                override fun onTranslationAndLanguage(word: Words?) {
-                    word?.let { callback?.onTranslationAndLanguage(it) }
-                }
-
-                override fun onDataNotAvailable() {callback?.onDataNotAvailable()}
-
+        val result = wordRepository.getTranslation(text, languageFrom, languageTo)
+        mMainThread.post {
+            when(result){
+                is Result.Success -> callback?.onTranslationAndLanguage(Words(text, result.data.src, result.data.translatedText))
+                is Result.Error -> callback?.onDataNotAvailable()
             }
-        )
+        }
     }
 
     interface Callback{

--- a/app/src/sharedTest/java/com/guillermonegrete/tts/data/source/FakeWordRepository.kt
+++ b/app/src/sharedTest/java/com/guillermonegrete/tts/data/source/FakeWordRepository.kt
@@ -34,10 +34,6 @@ class FakeWordRepository @Inject constructor(): WordRepositorySource {
         return languagesData.toMutableList()
     }
 
-    override fun getWordLanguageInfo(wordText: String?, callback: WordRepositorySource.GetWordRepositoryCallback?) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-
     override fun getWordLanguageInfo(
         wordText: String,
         languageFrom: String,

--- a/app/src/test/java/com/guillermonegrete/tts/data/source/WordRepositoryTest.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/data/source/WordRepositoryTest.kt
@@ -32,7 +32,7 @@ class WordRepositoryTest {
 
         fakeTranslator = FakeTranslatorSource()
 
-        repository = WordRepository(fakeRemoteSource, fakeLocalSource, fakeTranslator)
+        repository = WordRepository(fakeLocalSource, fakeTranslator)
     }
 
     @Test


### PR DESCRIPTION
Changed the dependency for getting translations, replaced `WordSourceData` with `TranslationSource`. The main reason was that the former has many methods like saving, deleting, and updating data which are not relevant for this use case.