### PR TITLE
Pr/update kotlin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,6 +81,8 @@ ext {
 
 kapt {
     generateStubs = true
+    // Required by hilt: https://dagger.dev/hilt/gradle-setup
+    correctErrorTypes = true
 }
 
 dependencies {
@@ -178,12 +180,9 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
 
     // Hilt
-    def hilt_version = "2.38"
+    def hilt_version = "2.38.1"
     implementation "com.google.dagger:hilt-android:$hilt_version"
     kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
-    def hiltAndroidXVersion = '1.0.0-alpha02'
-    implementation "androidx.hilt:hilt-lifecycle-viewmodel:$hiltAndroidXVersion"
-    kapt "androidx.hilt:hilt-compiler:$hiltAndroidXVersion"
 
     // Hilt testing
     androidTestImplementation "com.google.dagger:hilt-android-testing:$hilt_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: 'dagger.hilt.android.plugin'
@@ -8,7 +7,6 @@ apply plugin: "androidx.navigation.safeargs"
 
 android {
     compileSdkVersion 28
-    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "com.guillermonegrete.tts"
@@ -146,7 +144,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
-    implementation "android.arch.lifecycle:common-java8:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
@@ -181,7 +178,7 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
 
     // Hilt
-    def hilt_version = "2.29-alpha"
+    def hilt_version = "2.38"
     implementation "com.google.dagger:hilt-android:$hilt_version"
     kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
     def hiltAndroidXVersion = '1.0.0-alpha02'

--- a/app/src/androidTest/java/com/guillermonegrete/tts/di/TestApplicationModule.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/di/TestApplicationModule.kt
@@ -6,7 +6,7 @@ import com.guillermonegrete.tts.data.source.*
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 
 /**
  * WordRepositorySource binding to use in tests.
@@ -14,7 +14,7 @@ import dagger.hilt.android.components.ApplicationComponent
  * Hilt will inject a [FakeWordRepository] instead of a [WordRepository].
  */
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 abstract class TestApplicationModuleBinds {
 
     @Binds

--- a/app/src/main/java/com/guillermonegrete/tts/di/ApplicationModule.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/di/ApplicationModule.kt
@@ -34,7 +34,6 @@ import javax.inject.Qualifier
 import javax.inject.Singleton
 import dagger.Binds
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
@@ -162,7 +161,7 @@ object ApplicationModule {
     fun provideGoogleApi(retrofit: Retrofit) = retrofit.create(GooglePublicAPI::class.java)
 }
 
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 @Module
 abstract class ApplicationModuleBinds {
 
@@ -185,7 +184,7 @@ abstract class ApplicationModuleBinds {
 /**
  * The binding for WordRepositorySource is on its own module so that we can replace it easily in tests.
  */
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 @Module
 abstract class WordRepositorySourceModule {
     @Binds
@@ -200,7 +199,7 @@ abstract class WordRepositorySourceModule {
  * dagger can't determine how to create the instance if multiple methods return
  * the same type in the same module.
  */
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 @Module
 class GoogleSourceModule{
     @Provides
@@ -210,7 +209,7 @@ class GoogleSourceModule{
     fun provideGooglePublicSource(api: GooglePublicAPI): TranslationSource = GooglePublicSource(api)
 }
 
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 @Module
 class FirebaseLocalModule{
     @Provides

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/ImportTextViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/ImportTextViewModel.kt
@@ -1,20 +1,22 @@
 package com.guillermonegrete.tts.importtext
 
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.*
 import com.guillermonegrete.tts.Event
 import com.guillermonegrete.tts.data.source.FileRepository
 import com.guillermonegrete.tts.db.BookFile
 import com.guillermonegrete.tts.importtext.visualize.io.EpubFileManager
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @FlowPreview
 @ExperimentalCoroutinesApi
-class ImportTextViewModel @ViewModelInject constructor(
+@HiltViewModel
+class ImportTextViewModel @Inject constructor(
     private val fileRepository: FileRepository,
     fileManager: EpubFileManager
 ): ViewModel() {

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModel.kt
@@ -1,6 +1,5 @@
 package com.guillermonegrete.tts.importtext.visualize
 
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -16,11 +15,14 @@ import com.guillermonegrete.tts.importtext.epub.Book
 import com.guillermonegrete.tts.importtext.visualize.model.Span
 import com.guillermonegrete.tts.importtext.visualize.model.SplitPageSpan
 import com.guillermonegrete.tts.main.domain.interactors.GetLangAndTranslation
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
 import java.io.File
 import java.util.*
+import javax.inject.Inject
 
-class VisualizeTextViewModel @ViewModelInject constructor(
+@HiltViewModel
+class VisualizeTextViewModel @Inject constructor(
     private val epubParser: EpubParser,
     private val settings: SettingsRepository,
     private val fileRepository: FileRepository,

--- a/app/src/main/java/com/guillermonegrete/tts/savedwords/SavedWordsViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/savedwords/SavedWordsViewModel.kt
@@ -1,17 +1,19 @@
 package com.guillermonegrete.tts.savedwords
 
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.*
 import com.guillermonegrete.tts.data.source.WordRepositorySource
 
 import com.guillermonegrete.tts.db.Words
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
+import javax.inject.Inject
 
 /**
  * Production dispatcher is always Dispatchers.IO, we only inject the dispatcher when testing
  * The official docs recommend to inject Dispatchers.Unconfined when testing code using withContext()
  */
-class SavedWordsViewModel @ViewModelInject constructor(
+@HiltViewModel
+class SavedWordsViewModel @Inject constructor(
     private val wordRepository: WordRepositorySource,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ViewModel() {

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
@@ -1,6 +1,5 @@
 package com.guillermonegrete.tts.webreader
 
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -14,10 +13,13 @@ import com.guillermonegrete.tts.importtext.visualize.model.Span
 import com.guillermonegrete.tts.importtext.visualize.model.SplitPageSpan
 import com.guillermonegrete.tts.textprocessing.domain.interactors.GetExternalLink
 import com.guillermonegrete.tts.webreader.model.WordAndLinks
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
 import org.jsoup.Jsoup
+import javax.inject.Inject
 
-class WebReaderViewModel @ViewModelInject constructor(
+@HiltViewModel
+class WebReaderViewModel @Inject constructor(
     private val getTranslationInteractor: GetLangAndTranslation,
     private val getExternalLinksInteractor: GetExternalLink
 ): ViewModel() {

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.5.21'
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
-        classpath 'com.google.gms:google-services:4.3.4'
+        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.google.gms:google-services:4.3.10'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.29-alpha'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.38'
         def nav_version = "2.3.5"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 
@@ -24,7 +24,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
         maven { url "https://maven.google.com" }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
Updated to kotlin 1.5.21, android gradle plugin, added mavencentral, also had to update to the latest version of Hilt, 2.38.1 because of compatibility issues with 2.29-alpha and the new Kotlin version.

Some changes from the latest Hilt version:
- `ApplicationComponent` changed to `SingletonComponent`
- `ViewModelInject` annotation was deprecated, use `Inject` and `HiltViewModel` annotations

