### PR TITLE
Bugfix/#72 wrong text on rotation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,7 +130,7 @@ dependencies {
     annotationProcessor "androidx.room:room-compiler:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
-    androidTestImplementation "androidx.room:room-testing:2.2.5"
+    androidTestImplementation "androidx.room:room-testing:$room_version"
 
     // Retrofit
     implementation 'com.squareup.retrofit2:retrofit:2.5.0'

--- a/app/schemas/com.guillermonegrete.tts.db.FilesDatabase/4.json
+++ b/app/schemas/com.guillermonegrete.tts.db.FilesDatabase/4.json
@@ -1,0 +1,94 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "5e44dd94b6da8c70535ac55dad3a8633",
+    "entities": [
+      {
+        "tableName": "book_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uri` TEXT NOT NULL, `title` TEXT NOT NULL, `fileType` TEXT NOT NULL, `language` TEXT NOT NULL, `folderPath` TEXT NOT NULL, `page` INTEGER NOT NULL, `last_character` INTEGER NOT NULL, `chapter` INTEGER NOT NULL, `percentageDone` INTEGER NOT NULL, `lastRead` INTEGER NOT NULL, `bookFileId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "fileType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderPath",
+            "columnName": "folderPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChar",
+            "columnName": "last_character",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapter",
+            "columnName": "chapter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percentageDone",
+            "columnName": "percentageDone",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastRead",
+            "columnName": "lastRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "bookFileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "bookFileId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5e44dd94b6da8c70535ac55dad3a8633')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/guillermonegrete/tts/importtext/ImportTextFragmentTest.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/importtext/ImportTextFragmentTest.kt
@@ -87,7 +87,11 @@ class ImportTextFragmentTest{
         val tempFile = testFolder.newFile("copied_file.epub")
 
         runBlocking {
-            repository.saveFile(BookFile(tempFile.toUri().toString(), "Test book", ImportedFileType.EPUB))
+            repository.saveFile(BookFile(
+                tempFile.toUri().toString(),
+                "Test book",
+                ImportedFileType.EPUB
+            ))
         }
 
         launchFragmentInHiltContainer<ImportTextFragment>(bundleOf(), R.style.AppTheme)

--- a/app/src/main/java/com/guillermonegrete/tts/db/BookFile.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/db/BookFile.kt
@@ -21,7 +21,13 @@ data class BookFile(
      *  TODO page is not a good indicator of the current position because page size varies, replace with last character.
      *  This is problematic specially when rotating screen because the number of pages changes.
      */
+    @Deprecated("Use the last character field instead")
     var page: Int = 0,
+    /**
+     * The position of the character that the user
+     */
+    @ColumnInfo(name = "last_character")
+    var lastChar: Int = 0,
     var chapter: Int = 0,
     var percentageDone: Int = 0,
     var lastRead: Calendar = Calendar.getInstance(),

--- a/app/src/main/java/com/guillermonegrete/tts/db/FilesDatabase.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/db/FilesDatabase.kt
@@ -8,7 +8,10 @@ import androidx.room.TypeConverters
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [BookFile::class], version = 3)
+@Database(
+    version = 4,
+    entities = [BookFile::class]
+)
 @TypeConverters(Converters::class)
 abstract class FilesDatabase: RoomDatabase() {
     abstract fun fileDao(): FileDAO
@@ -19,7 +22,7 @@ abstract class FilesDatabase: RoomDatabase() {
                 context.applicationContext,
                 FilesDatabase::class.java,
                 "files.db")
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_2_3, MIGRATION_3_4)
                 .build()
         }
 
@@ -32,6 +35,12 @@ abstract class FilesDatabase: RoomDatabase() {
         val MIGRATION_2_3 = object : Migration(2, 3) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("ALTER TABLE book_files ADD COLUMN folderPath TEXT NOT NULL DEFAULT ''")
+            }
+        }
+
+        val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE book_files ADD COLUMN last_character INTEGER NOT NULL DEFAULT 0")
             }
         }
     }

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModel.kt
@@ -380,7 +380,7 @@ class VisualizeTextViewModel @Inject constructor(
 
         currentPages.forEachIndexed { index, page ->
             acc += page.length
-            if(charPos <= acc) return index
+            if(charPos < acc) return index
         }
 
         return 0

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModel.kt
@@ -180,7 +180,8 @@ class VisualizeTextViewModel @Inject constructor(
     fun getPage(): Int{
         currentPage = if(firstLoad) {
             firstLoad = false
-            val initialPage = if(currentPage == -1) databaseBookFile?.page ?: 0 else currentPage
+            val lastChar = databaseBookFile?.lastChar ?: 0
+            val initialPage = if(currentPage == -1) getPageIndex(lastChar) else currentPage
             if (initialPage >= pagesSize) pagesSize - 1 else initialPage
         } else if(leftSwipe) pagesSize - 1 else 0
 
@@ -322,8 +323,9 @@ class VisualizeTextViewModel @Inject constructor(
         runBlocking{
             val progress = calculateProgress()
 
+            val charPos = getCharPos()
             databaseBookFile?.apply {
-                page = currentPage
+                lastChar = charPos
                 chapter = currentChapter
                 lastRead = date
                 percentageDone = progress
@@ -336,7 +338,7 @@ class VisualizeTextViewModel @Inject constructor(
                 title,
                 fileType,
                 folderPath = path,
-                page = currentPage,
+                lastChar = charPos,
                 chapter = currentChapter,
                 percentageDone =  calculateProgress(),
                 lastRead =  date
@@ -365,6 +367,35 @@ class VisualizeTextViewModel @Inject constructor(
         percentage = 100 * sumPreviousChars / book.totalChars
 
         return percentage
+    }
+
+    /**
+     * Gets the page that contains [charPos]
+     * For example, the third page ranges from 20 to 35, a char with position 23 would be inside that page.
+     *
+     * @return The page number that contains the character. Returns zero if none contains it.
+     */
+    private fun getPageIndex(charPos: Int): Int{
+        var acc = 0
+
+        currentPages.forEachIndexed { index, page ->
+            acc += page.length
+            if(charPos <= acc) return index
+        }
+
+        return 0
+    }
+
+    /**
+     * Returns the character position of the first element of the current page.
+     * For example, the third page ranges from 20 to 35, it returns 20.
+     */
+    private fun getCharPos(): Int {
+        var sum = 0
+        for (i in 0 until currentPage){
+            sum += currentPages[i].length
+        }
+        return sum
     }
 
     fun onTranslatedTextClick(page: Int, charIndex: Int) {

--- a/app/src/test/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModelTest.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModelTest.kt
@@ -181,7 +181,8 @@ class VisualizeTextViewModelTest {
     fun epub_first_load_set_predefined_page(){
         // Set up
         val initialPage = 4
-        bookFile.page = initialPage
+        val initialChar = 41
+        bookFile.lastChar = initialChar
         fileRepository.addTasks(bookFile)
 
         splitPages(8)
@@ -202,8 +203,9 @@ class VisualizeTextViewModelTest {
     fun when_changed_to_previous_chapter_set_last_page(){
         // Set up
         val initialPage = 2
+        val initialChar = 20
         val initialChapter = 1
-        bookFile.page = initialPage
+        bookFile.lastChar = initialChar
         bookFile.chapter = initialChapter
         fileRepository.addTasks(bookFile)
 
@@ -225,8 +227,8 @@ class VisualizeTextViewModelTest {
     @Test
     fun when_changed_to_next_chapter_set_first_page(){
         // Set up
-        val initialPage = 2
-        bookFile.page = initialPage
+        val initialChar = 20
+        bookFile.lastChar = initialChar
         fileRepository.addTasks(bookFile)
 
         splitPages(3)
@@ -235,6 +237,7 @@ class VisualizeTextViewModelTest {
 
         // Returns initial page in first load
         val page = viewModel.getPage()
+        val initialPage = 2
         assertEquals(initialPage, page)
 
         // Second load
@@ -299,7 +302,7 @@ class VisualizeTextViewModelTest {
             DEFAULT_BOOK.metadata.title,
             ImportedFileType.EPUB,
             folderPath = uuid,
-            page = initialPage,
+            lastChar = 50,
             chapter = 3,
             percentageDone = 100 * sumPreviousChars / DEFAULT_BOOK.totalChars,
             lastRead = lastReadDate
@@ -400,6 +403,7 @@ class VisualizeTextViewModelTest {
             book.title,
             book.fileType,
             folderPath = uuid,
+            percentageDone = 2, // it considers the first page as completed 10/500 = 2%
             lastRead = lastReadDate,
             id = book.id,
         )
@@ -472,7 +476,7 @@ class VisualizeTextViewModelTest {
     }
 
     private fun splitPages(pagesSize: Int){
-        val pages = Array(pagesSize) {"n"}.toList()
+        val pages = Array(pagesSize) { "n".repeat(10) }.toList()
         `when`(pageSplitter.getPages()).thenReturn(pages)
     }
 
@@ -489,7 +493,7 @@ class VisualizeTextViewModelTest {
 
         // Sum of previous pages
         for(i in 0..pageIndex){
-            sumPreviousChars += 1 // Every page only has one character
+            sumPreviousChars += 10 // Every page only has one character
         }
 
         println("Sum previous pages $sumPreviousChars")
@@ -503,7 +507,7 @@ class VisualizeTextViewModelTest {
         private val DEFAULT_BOOK = Book(
             EPUBMetadata("Test title", "", "", "coverId"),
             DEFAULT_CHAPTER,
-            Array(5){SpineItem("$it", "ch${it + 1}.html", it + 100)}.toList(),
+            Array(5){SpineItem("$it", "ch${it + 1}.html", 100)}.toList(),
             mapOf("0" to "ch1.html", "1" to "ch2.html", "2" to "ch3.html", "3" to "ch4.html", "4" to "ch5.html", "coverId" to "cover-jpg"),
             TableOfContents(listOf())
         )

--- a/app/src/test/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModelTest.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModelTest.kt
@@ -48,7 +48,13 @@ class VisualizeTextViewModelTest {
 
     @Mock private lateinit var pageSplitter: PageSplitter
 
-    private val bookFile = BookFile("empty_uri", "Title", ImportedFileType.EPUB, id = 1, folderPath = "random_path")
+    private val bookFile = BookFile(
+        "empty_uri",
+        "Title",
+        ImportedFileType.EPUB,
+        folderPath = "random_path",
+        id = 1
+    )
 
     @Before
     fun setUp(){
@@ -295,8 +301,8 @@ class VisualizeTextViewModelTest {
             folderPath = uuid,
             page = initialPage,
             chapter = 3,
-            lastRead = lastReadDate,
-            percentageDone = 100 * sumPreviousChars / DEFAULT_BOOK.totalChars
+            percentageDone = 100 * sumPreviousChars / DEFAULT_BOOK.totalChars,
+            lastRead = lastReadDate
         )
         val resultFile = fileRepository.filesServiceData.values.first()
         assertEquals(1, fileRepository.filesServiceData.values.size)
@@ -361,10 +367,10 @@ class VisualizeTextViewModelTest {
             bookFile.title,
             bookFile.fileType,
             folderPath = bookFile.folderPath,
-            id = bookFile.id,
             chapter = initialChapter + 1,
+            percentageDone = 100 * sumPreviousChars / DEFAULT_BOOK.totalChars,
             lastRead = lastReadDate,
-            percentageDone = 100 * sumPreviousChars / DEFAULT_BOOK.totalChars
+            id = bookFile.id
         )
         val resultFile = fileRepository.filesServiceData.values.first()
         assertEquals(1, fileRepository.filesServiceData.values.size)
@@ -375,7 +381,7 @@ class VisualizeTextViewModelTest {
     @Test
     fun `Creates new folder path for book file if empty`(){
         // TODO this test and "Updates book files" test are very similar, try to refactor
-        val book = BookFile("default_uri", "Title", ImportedFileType.EPUB, id = 1, folderPath = "")
+        val book = BookFile("default_uri", "Title", ImportedFileType.EPUB, folderPath = "", id = 1)
 
         fileRepository.addTasks(book)
         viewModel.fileUri = bookFile.uri
@@ -394,8 +400,8 @@ class VisualizeTextViewModelTest {
             book.title,
             book.fileType,
             folderPath = uuid,
-            id = book.id,
             lastRead = lastReadDate,
+            id = book.id,
         )
 
         val resultFile = fileRepository.filesServiceData.values.first()


### PR DESCRIPTION
Fixes #72. The app saves the position of the 1st char on the page instead of the page position. Because the char position is constant it can be used to find what is the page position (in case the page count changes for example during a screen rotation).