### PR TITLE
Feature/#89 sentence navigator

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,14 +44,6 @@ android {
     sourceSets {
         // Adds exported schema location as test app assets.
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
-
-        String sharedTestDir = 'src/sharedTest/java'
-        test {
-            java.srcDir sharedTestDir
-        }
-        androidTest {
-            java.srcDir sharedTestDir
-        }
     }
 
     buildFeatures {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,6 @@ repositories {
     maven() {
         url "https://oss.sonatype.org/content/repositories/snapshots"
     }
-    jcenter()
     maven { url 'https://jitpack.io' }
 }
 
@@ -187,6 +186,10 @@ dependencies {
 
     // Jsoup HTML parser
     implementation 'org.jsoup:jsoup:1.13.1'
+
+    // Okhttp
+    implementation(platform("com.squareup.okhttp3:okhttp-bom:4.10.0"))
+    androidTestImplementation "com.squareup.okhttp3:mockwebserver:4.10.0"
 
     // Instrumental testing
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -200,6 +200,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation "androidx.arch.core:core-testing:2.1.0"
+    androidTestImplementation 'androidx.test:rules:1.4.0'
     def espressoVersion = "3.3.0"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$espressoVersion"

--- a/app/src/androidTest/assets/test_page.html
+++ b/app/src/androidTest/assets/test_page.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>My First Heading</h1>
+<p>My first paragraph.</p>
+</body>
+</html>

--- a/app/src/androidTest/assets/test_page.html
+++ b/app/src/androidTest/assets/test_page.html
@@ -2,6 +2,7 @@
 <html>
 <body>
 <h1>My First Heading</h1>
-<p>My first paragraph.</p>
+<span>Body first paragraph</span>
+<p>My second paragraph.</p>
 </body>
 </html>

--- a/app/src/androidTest/java/com/guillermonegrete/tts/HiltExt.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/HiltExt.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import androidx.annotation.StyleRes
 import androidx.core.util.Preconditions
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.testing.FragmentScenario.EmptyFragmentActivity
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 
@@ -29,7 +28,10 @@ inline fun <reified T : Fragment> launchFragmentInHiltContainer(
             ApplicationProvider.getApplicationContext(),
             HiltTestActivity::class.java
         )
-    ).putExtra(EmptyFragmentActivity.THEME_EXTRAS_BUNDLE_KEY, themeResId)
+    ).putExtra(
+        "androidx.fragment.app.testing.FragmentScenario.EmptyFragmentActivity.THEME_EXTRAS_BUNDLE_KEY",
+        themeResId
+    )
 
     ActivityScenario.launch<HiltTestActivity>(startActivityIntent).onActivity { activity ->
         val fragment: Fragment = activity.supportFragmentManager.fragmentFactory.instantiate(

--- a/app/src/androidTest/java/com/guillermonegrete/tts/data/source/FakeWordRepository.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/data/source/FakeWordRepository.kt
@@ -3,6 +3,7 @@ package com.guillermonegrete.tts.data.source
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.liveData
 import com.guillermonegrete.tts.data.Result
 import com.guillermonegrete.tts.data.Translation
 import com.guillermonegrete.tts.db.Words
@@ -28,6 +29,10 @@ class FakeWordRepository @Inject constructor(): WordRepositorySource {
 
     override fun getWordsStream(): LiveData<MutableList<Words>> {
         return MutableLiveData(wordsServiceData.values.toMutableList())
+    }
+
+    override fun getLocalWord(word: String, language: String): LiveData<Words> {
+        return  liveData { wordsServiceData[word]?.let { emit(it) } }
     }
 
     override fun getLanguagesISO(): MutableList<String> {
@@ -73,8 +78,8 @@ class FakeWordRepository @Inject constructor(): WordRepositorySource {
         languageFrom: String,
         languageTo: String
     ): Result<Translation> {
-        val word = translationsData[text] ?: return Result.Error(Exception("Translation not found"))
-        return Result.Success(word)
+        val translation = translationsData[text] ?: return Result.Error(Exception("Translation not found"))
+        return Result.Success(translation)
     }
 
     override fun deleteWord(word: String?) {

--- a/app/src/androidTest/java/com/guillermonegrete/tts/di/TestApplicationModule.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/di/TestApplicationModule.kt
@@ -44,3 +44,18 @@ object FileMemoryDatabaseModule {
         return Room.inMemoryDatabaseBuilder(context, FilesDatabase::class.java).build()
     }
 }
+
+/**
+ * Replaces all the network server with the url of the MockWebServer.
+ */
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [NetworkModule::class]
+)
+object MockNetworkModule {
+
+    @Provides
+    fun provideTestBaseUrl() = "http://localhost:8081"
+
+}

--- a/app/src/androidTest/java/com/guillermonegrete/tts/importtext/ImportTextFragmentTest.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/importtext/ImportTextFragmentTest.kt
@@ -1,5 +1,6 @@
 package com.guillermonegrete.tts.importtext
 
+import android.Manifest
 import android.app.Activity
 import android.app.Instrumentation
 import android.content.Intent
@@ -19,7 +20,9 @@ import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
 import com.guillermonegrete.tts.R
+import com.guillermonegrete.tts.data.preferences.SettingsRepository
 import com.guillermonegrete.tts.data.source.DefaultFileRepository
 import com.guillermonegrete.tts.db.BookFile
 import com.guillermonegrete.tts.di.WordRepositorySourceModule
@@ -30,6 +33,7 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -48,8 +52,14 @@ class ImportTextFragmentTest{
     @get:Rule
     var hiltRule = HiltAndroidRule(this)
 
+    @get:Rule
+    val runtimePermissionRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE)
+
     @Inject
     lateinit var repository: DefaultFileRepository
+
+    @Inject
+    lateinit var settingsRepository: SettingsRepository
 
     @get:Rule
     var testFolder = TemporaryFolder()
@@ -83,6 +93,7 @@ class ImportTextFragmentTest{
 
     @Test
     fun given_one_recent_file_when_clicked_then_navigate_to_visualizer(){
+        runTest { settingsRepository.setImportTabPosition(ImportTextFragment.FilesIndex) }
 
         val tempFile = testFolder.newFile("copied_file.epub")
 
@@ -104,6 +115,7 @@ class ImportTextFragmentTest{
 
     @Test
     fun when_file_added_then_navigate_to_visualizer(){
+        runTest { settingsRepository.setImportTabPosition(ImportTextFragment.FilesIndex) }
 
         launchFragmentInHiltContainer<ImportTextFragment>(bundleOf(), R.style.AppTheme)
 
@@ -126,7 +138,7 @@ class ImportTextFragmentTest{
 
         launchFragmentInHiltContainer<ImportTextFragment>(bundleOf(), R.style.AppTheme)
 
-        onView(withId(R.id.import_tab_layout)).perform(selectTabAtPosition(1))
+        onView(withId(R.id.import_tab_layout)).perform(selectTabAtPosition(ImportTextFragment.EnterTextIndex))
 
         // This can cause the tab to suddenly change, making the test fail
         // A fix hasn't been found yet

--- a/app/src/androidTest/java/com/guillermonegrete/tts/main/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/main/MainActivityTest.kt
@@ -1,4 +1,4 @@
-package com.guillermonegrete.tts.main;
+package com.guillermonegrete.tts.main
 
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario

--- a/app/src/androidTest/java/com/guillermonegrete/tts/textprocessing/TextInfoDialogTest.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/textprocessing/TextInfoDialogTest.kt
@@ -131,13 +131,14 @@ class TextInfoDialogTest {
     }
 
     @Test
-    fun extraWord_showDictWithWordLayout(){
+    fun given_saved_extra_word_then_dict_layout_with_edit_icon(){
 
         val inputWord = Words("prueba", "ES", "test")
 
         val bundle = Bundle().apply {
             putString(TextInfoDialog.TEXT_KEY, inputWord.word)
             putParcelable(TextInfoDialog.WORD_KEY, inputWord)
+            putBoolean(TextInfoDialog.WORD_SAVED_KEY, true)
             putString(TextInfoDialog.ACTION_KEY, TextInfoDialog.NO_SERVICE)
         }
 

--- a/app/src/androidTest/java/com/guillermonegrete/tts/utils/EspressoUtils.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/utils/EspressoUtils.kt
@@ -1,8 +1,13 @@
 package com.guillermonegrete.tts.utils
 
+import android.view.InputDevice
+import android.view.MotionEvent
 import android.view.View
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
+import androidx.test.espresso.action.GeneralClickAction
+import androidx.test.espresso.action.Press
+import androidx.test.espresso.action.Tap
 import androidx.test.espresso.matcher.ViewMatchers
 import com.google.android.material.tabs.TabLayout
 import org.hamcrest.CoreMatchers
@@ -28,4 +33,23 @@ fun selectTabAtPosition(position: Int): ViewAction {
             }
         }
     }
+}
+
+/**
+ * Performs a click in the given coordinates
+ */
+fun clickIn(x: Int, y: Int): ViewAction {
+    return GeneralClickAction(
+        Tap.SINGLE, { view ->
+            val screenPos = IntArray(2)
+            view?.getLocationOnScreen(screenPos)
+
+            val screenX = (screenPos[0] + x).toFloat()
+            val screenY = (screenPos[1] + y).toFloat()
+
+            floatArrayOf(screenX, screenY)
+        },
+        Press.FINGER,
+        InputDevice.SOURCE_MOUSE,
+        MotionEvent.BUTTON_PRIMARY)
 }

--- a/app/src/androidTest/java/com/guillermonegrete/tts/webreader/WebReaderFragmentTest.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/webreader/WebReaderFragmentTest.kt
@@ -47,8 +47,6 @@ class WebReaderFragmentTest{
         val args = bundleOf("link" to "https://en.wikipedia.org/wiki/Wiktionary")
         launchFragmentInHiltContainer<WebReaderFragment>(args, R.style.AppTheme)
 
-        onView(withId(R.id.paragraphs_list)).check(matches(not(isDisplayed())))
-        onView(withId(R.id.list_toggle)).perform(click())
-        onView(withId(R.id.body_text)).check(matches(not(isDisplayed())))
+        onView(withId(R.id.paragraphs_list)).check(matches(isDisplayed()))
     }
 }

--- a/app/src/androidTest/java/com/guillermonegrete/tts/webreader/WebReaderFragmentTest.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/webreader/WebReaderFragmentTest.kt
@@ -87,13 +87,14 @@ class WebReaderFragmentTest{
                 RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click())
             )
 
-        Thread.sleep(1000)
+        Thread.sleep(500) // it's necessary to wait for the single tap confirmed event in the ParagraphAdapter
         onView(withId(R.id.menu_bar)).check(matches(not(isDisplayed())))
 
         onView(withId(R.id.translated_text)).check(matches(isDisplayed()))
         onView(withId(R.id.translated_text)).check(matches(withText("My")))
 
         onView(withId(R.id.more_info_btn)).perform(click())
+        onView(withId(R.id.info_webview)).check(matches(isDisplayed()))
     }
 
     @Test

--- a/app/src/androidTest/java/com/guillermonegrete/tts/webreader/WebReaderFragmentTest.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/webreader/WebReaderFragmentTest.kt
@@ -1,14 +1,17 @@
 package com.guillermonegrete.tts.webreader
 
 import androidx.core.os.bundleOf
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
+import androidx.test.platform.app.InstrumentationRegistry
 import com.guillermonegrete.tts.R
 import com.guillermonegrete.tts.di.WordRepositorySourceModule
 import com.guillermonegrete.tts.launchFragmentInHiltContainer
@@ -16,12 +19,14 @@ import com.guillermonegrete.tts.utils.EspressoIdlingResource
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
-import org.hamcrest.Matchers.not
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+
 
 @MediumTest
 @RunWith(AndroidJUnit4::class)
@@ -31,6 +36,19 @@ class WebReaderFragmentTest{
 
     @get:Rule
     var hiltRule = HiltAndroidRule(this)
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setup(){
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun teardown(){
+        server.shutdown()
+    }
 
     @Before
     fun registerIdlingResource() {
@@ -44,9 +62,21 @@ class WebReaderFragmentTest{
 
     @Test
     fun given_default_layout_when_toggle_button_then_paragraph_layout(){
-        val args = bundleOf("link" to "https://en.wikipedia.org/wiki/Wiktionary")
+        val body = readPage()
+        server.enqueue(MockResponse().setBody(body))
+
+        val args = bundleOf("link" to server.url("/").toString())
         launchFragmentInHiltContainer<WebReaderFragment>(args, R.style.AppTheme)
 
         onView(withId(R.id.paragraphs_list)).check(matches(isDisplayed()))
+
+        onView(withId(R.id.paragraphs_list))
+            .perform(
+                RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click())
+            )
     }
+
+    private fun readPage() =
+        InstrumentationRegistry.getInstrumentation()
+            .context.assets.open("test_epub.epub").bufferedReader().use { it.readText() }
 }

--- a/app/src/androidTest/java/com/guillermonegrete/tts/webreader/WebReaderFragmentTest.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/webreader/WebReaderFragmentTest.kt
@@ -19,6 +19,7 @@ import com.guillermonegrete.tts.data.source.remote.Sentence
 import com.guillermonegrete.tts.di.TestApplicationModuleBinds
 import com.guillermonegrete.tts.launchFragmentInHiltContainer
 import com.guillermonegrete.tts.utils.EspressoIdlingResource
+import com.guillermonegrete.tts.utils.clickIn
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -72,7 +73,7 @@ class WebReaderFragmentTest{
     }
 
     @Test
-    fun given_default_layout_when_toggle_button_then_paragraph_layout(){
+    fun when_word_tapped_then_translation_shown(){
         val body = readPage()
         server.enqueue(MockResponse().setBody(body))
 
@@ -87,7 +88,9 @@ class WebReaderFragmentTest{
 
         onView(withId(R.id.paragraphs_list))
             .perform(
-                RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click())
+                // The regular click() is performed in the center of the view, this makes the click position vary and sometimes empty text is returned
+                // Click on the (0, 0) position to ensure the first word is clicked
+                RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, clickIn(0, 0))
             )
 
         Thread.sleep(500) // it's necessary to wait for the single tap confirmed event in the ParagraphAdapter
@@ -170,11 +173,11 @@ class WebReaderFragmentTest{
 
     companion object{
         const val FIRST_SENTENCE = "My First Heading\n"
-        const val FIRST_SENTENCE_TRANS = "Primer encabezado"
+        private const val FIRST_SENTENCE_TRANS = "Primer encabezado"
         const val SECOND_SENTENCE = "Body first paragraph"
-        const val SECOND_SENTENCE_TRANS = "Cuerpo del primer parrafo"
+        private const val SECOND_SENTENCE_TRANS = "Cuerpo del primer parrafo"
         const val THIRD_SENTENCE = "My second paragraph."
-        const val THIRD_SENTENCE_TRANS = "Mi segundo parrafo"
+        private const val THIRD_SENTENCE_TRANS = "Mi segundo parrafo"
 
         val sentencesTranslationResponses = listOf(
             GoogleTranslateResponse(listOf(Sentence(FIRST_SENTENCE_TRANS, FIRST_SENTENCE)), "en"),

--- a/app/src/androidTest/java/com/guillermonegrete/tts/webreader/WebReaderFragmentTest.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/webreader/WebReaderFragmentTest.kt
@@ -5,22 +5,27 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.longClick
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.guillermonegrete.tts.R
-import com.guillermonegrete.tts.di.WordRepositorySourceModule
+import com.guillermonegrete.tts.data.source.remote.GoogleTranslateResponse
+import com.guillermonegrete.tts.data.source.remote.Sentence
+import com.guillermonegrete.tts.di.TestApplicationModuleBinds
 import com.guillermonegrete.tts.launchFragmentInHiltContainer
 import com.guillermonegrete.tts.utils.EspressoIdlingResource
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.hamcrest.CoreMatchers.not
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -30,7 +35,7 @@ import org.junit.runner.RunWith
 
 @MediumTest
 @RunWith(AndroidJUnit4::class)
-@UninstallModules(WordRepositorySourceModule::class)
+@UninstallModules(TestApplicationModuleBinds::class)
 @HiltAndroidTest
 class WebReaderFragmentTest{
 
@@ -39,10 +44,13 @@ class WebReaderFragmentTest{
 
     private lateinit var server: MockWebServer
 
+    private val moshi: Moshi = Moshi.Builder().build()
+    private val responseAdapter: JsonAdapter<GoogleTranslateResponse> = moshi.adapter(GoogleTranslateResponse::class.java)
+
     @Before
     fun setup(){
         server = MockWebServer()
-        server.start()
+        server.start(8081)
     }
 
     @After
@@ -70,13 +78,49 @@ class WebReaderFragmentTest{
 
         onView(withId(R.id.paragraphs_list)).check(matches(isDisplayed()))
 
+        val response = GoogleTranslateResponse(listOf(Sentence("My", "Mi")), "es")
+        val jsonResponse = responseAdapter.toJson(response)
+        server.enqueue(MockResponse().setBody(jsonResponse))
+
         onView(withId(R.id.paragraphs_list))
             .perform(
                 RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click())
             )
+
+        Thread.sleep(1000)
+        onView(withId(R.id.menu_bar)).check(matches(not(isDisplayed())))
+
+        onView(withId(R.id.translated_text)).check(matches(isDisplayed()))
+        onView(withId(R.id.translated_text)).check(matches(withText("My")))
+
+        onView(withId(R.id.more_info_btn)).perform(click())
+    }
+
+    @Test
+    fun when_sentence_long_pressed_then_highlight(){
+        val body = readPage()
+        server.enqueue(MockResponse().setBody(body))
+
+        val args = bundleOf("link" to server.url("/").toString())
+        launchFragmentInHiltContainer<WebReaderFragment>(args, R.style.AppTheme)
+
+        onView(withId(R.id.paragraphs_list)).check(matches(isDisplayed()))
+
+        onView(withId(R.id.paragraphs_list))
+            .perform(
+                RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, longClick())
+            )
+
+        val response = GoogleTranslateResponse(listOf(Sentence("My", "My")), "en")
+        val jsonResponse = responseAdapter.toJson(response)
+        server.enqueue(MockResponse().setBody(jsonResponse))
+        onView(withId(R.id.translate)).perform(click())
+
+        onView(withId(R.id.translated_text)).check(matches(isDisplayed()))
+        onView(withId(R.id.translated_text)).check(matches(withText("My")))
     }
 
     private fun readPage() =
         InstrumentationRegistry.getInstrumentation()
-            .context.assets.open("test_epub.epub").bufferedReader().use { it.readText() }
+            .context.assets.open("test_page.html").bufferedReader().use { it.readText() }
 }

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -2,7 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.guillermonegrete.tts">
 
-    <application>
+    <application
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".HiltTestActivity"
             android:exported="false"  />

--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Allows localhost connections, the localhost is used by OkHttp's MockWebServer for testing
+It should be only in the debug build-->
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+    </domain-config>
+</network-security-config>

--- a/app/src/main/java/com/guillermonegrete/tts/common/models/Span.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/common/models/Span.kt
@@ -1,0 +1,3 @@
+package com.guillermonegrete.tts.common.models
+
+data class Span(val start: Int, val end: Int)

--- a/app/src/main/java/com/guillermonegrete/tts/di/ApplicationModule.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/di/ApplicationModule.kt
@@ -3,8 +3,8 @@ package com.guillermonegrete.tts.di
 import android.app.Application
 import android.content.Context
 import android.content.SharedPreferences
-import android.preference.PreferenceManager
 import android.util.Xml
+import androidx.preference.PreferenceManager
 import androidx.room.Room
 import com.guillermonegrete.tts.MainThread
 import com.guillermonegrete.tts.customtts.CustomTTS
@@ -146,14 +146,14 @@ object ApplicationModule {
 
     @Singleton
     @Provides
-    fun provideGoogleRetrofit() = Retrofit.Builder()
-        .baseUrl(GooglePublicSource.BASE_URL)
-        .addConverterFactory(MoshiConverterFactory.create())
+    fun provideRetrofit(baseUrl: String): Retrofit = Retrofit.Builder()
+        .baseUrl(baseUrl)
+        .addConverterFactory(MoshiConverterFactory.create().asLenient())
         .build()
 
     @Singleton
     @Provides
-    fun provideGoogleApi(retrofit: Retrofit) = retrofit.create(GooglePublicAPI::class.java)
+    fun provideGoogleApi(retrofit: Retrofit): GooglePublicAPI = retrofit.create(GooglePublicAPI::class.java)
 }
 
 /**
@@ -168,6 +168,14 @@ object FilesDatabaseModule {
     fun provideFilesDatabase(@ApplicationContext context: Context): FilesDatabase{
         return FilesDatabase.getDatabase(context)
     }
+}
+
+@InstallIn(SingletonComponent::class)
+@Module
+object NetworkModule {
+
+    @Provides
+    fun provideGoogleBaseUrl() = GooglePublicSource.BASE_URL
 }
 
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/ImportTextFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/ImportTextFragment.kt
@@ -46,9 +46,9 @@ class ImportTextFragment: Fragment(R.layout.fragment_import_text) {
 
         TabLayoutMediator(binding.importTabLayout, pager) { tab, position ->
             tab.text = when (position) {
-                0 -> "Files"
-                1 -> "Links"
-                2 -> "Text"
+                FilesIndex -> "Files"
+                WebLinksIndex -> "Links"
+                EnterTextIndex -> "Text"
                 else -> ""
             }
         }.attach()
@@ -72,11 +72,18 @@ class ImportTextFragment: Fragment(R.layout.fragment_import_text) {
 
         override fun createFragment(position: Int): Fragment {
             return when(position){
-                0 -> FilesFragment()
-                1 -> WebLinksFragment.newInstance()
-                2 -> EnterTextFragment()
+                FilesIndex -> FilesFragment()
+                WebLinksIndex -> WebLinksFragment.newInstance()
+                EnterTextIndex -> EnterTextFragment()
                 else -> throw IllegalStateException("Out of position: $position")
             }
         }
+    }
+
+    companion object{
+
+        const val FilesIndex = 0
+        const val WebLinksIndex = 1
+        const val EnterTextIndex = 2
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.guillermonegrete.tts.Event
+import com.guillermonegrete.tts.common.models.Span
 import com.guillermonegrete.tts.data.Result
 import com.guillermonegrete.tts.data.Translation
 import com.guillermonegrete.tts.data.preferences.SettingsRepository
@@ -12,7 +13,6 @@ import com.guillermonegrete.tts.data.source.FileRepository
 import com.guillermonegrete.tts.db.BookFile
 import com.guillermonegrete.tts.importtext.ImportedFileType
 import com.guillermonegrete.tts.importtext.epub.Book
-import com.guillermonegrete.tts.importtext.visualize.model.Span
 import com.guillermonegrete.tts.importtext.visualize.model.SplitPageSpan
 import com.guillermonegrete.tts.main.domain.interactors.GetLangAndTranslation
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -215,7 +215,7 @@ class VisualizeTextViewModel @Inject constructor(
         databaseBookFile?.let {
 
             // Verify folderPath is not empty
-            val folderPath = if (it.folderPath.isBlank()) uuid else it.folderPath
+            val folderPath = it.folderPath.ifBlank { uuid }
 
             fileReader?.createFileFolder(folderPath)
 

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizerAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizerAdapter.kt
@@ -9,7 +9,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.guillermonegrete.tts.R
-import com.guillermonegrete.tts.importtext.visualize.model.Span
+import com.guillermonegrete.tts.common.models.Span
 import com.guillermonegrete.tts.utils.dpToPixel
 import java.text.BreakIterator
 import java.util.*

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/model/SplitPageSpan.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/model/SplitPageSpan.kt
@@ -1,5 +1,5 @@
 package com.guillermonegrete.tts.importtext.visualize.model
 
-data class Span(val start: Int, val end: Int)
+import com.guillermonegrete.tts.common.models.Span
 
 data class SplitPageSpan(val topSpan: Span, val bottomSpan: Span)

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
@@ -585,7 +585,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View, SaveWordDialog
         spinner.adapter = adapter
 
         spinner.setSelection(languageFromIndex, false)
-        spinner.onItemSelectedListener = SpinnerListener()
+        spinner.post { spinner.onItemSelectedListener = SpinnerListener() }
     }
 
     private fun setSpinner() {
@@ -601,7 +601,8 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View, SaveWordDialog
         spinner.adapter = adapter
 
         spinner.setSelection(languagePreferenceIndex, false)
-        spinner.onItemSelectedListener = SpinnerListener()
+        // the post{} avoids the listener being called when setting
+        spinner.post { spinner.onItemSelectedListener = SpinnerListener() }
     }
 
     override fun onWordSaved(word: Words) {

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TranslationFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TranslationFragment.kt
@@ -122,7 +122,7 @@ class TranslationFragment: Fragment(R.layout.fragment_process_translation) {
         spinner.apply {
             adapter = arrayAdapter
             spinnerIndex?.let { setSelection(it, false) }
-            onItemSelectedListener = SpinnerListener()
+            post { onItemSelectedListener = SpinnerListener() } // the post{} avoids the listener being called
         }
 
     }

--- a/app/src/main/java/com/guillermonegrete/tts/utils/TextViewExt.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/utils/TextViewExt.kt
@@ -1,0 +1,37 @@
+package com.guillermonegrete.tts.utils
+
+import android.widget.TextView
+
+/**
+ * Finds the word in the text view for the given [offset] obtained using [TextView.getOffsetForPosition].
+ */
+fun TextView.findWordForRightHanded(
+    offset: Int
+): String { // when you touch ' ', this method returns left word.
+    val str = text.toString()
+    var newOffset = offset
+    if (str.length == newOffset) {
+        newOffset-- // without this code, you will get exception when touching end of the text
+    }
+    if (str[newOffset] == ' ') {
+        newOffset--
+    }
+    var startIndex = newOffset
+    var endIndex = newOffset
+    try {
+        while (Character.isLetterOrDigit(str[startIndex])) {
+            startIndex--
+        }
+    } catch (e: StringIndexOutOfBoundsException) {
+        startIndex = 0
+    }
+    try {
+        while (Character.isLetterOrDigit(str[endIndex])) {
+            endIndex++
+        }
+    } catch (e: StringIndexOutOfBoundsException) {
+        endIndex = str.length
+    }
+
+    return str.substring(startIndex, endIndex)
+}

--- a/app/src/main/java/com/guillermonegrete/tts/utils/TextViewExt.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/utils/TextViewExt.kt
@@ -1,13 +1,14 @@
 package com.guillermonegrete.tts.utils
 
 import android.widget.TextView
+import com.guillermonegrete.tts.common.models.Span
 
 /**
  * Finds the word in the text view for the given [offset] obtained using [TextView.getOffsetForPosition].
  */
 fun TextView.findWordForRightHanded(
     offset: Int
-): String { // when you touch ' ', this method returns left word.
+): Span { // when you touch ' ', this method returns left word.
     val str = text.toString()
     var newOffset = offset
     if (str.length == newOffset) {
@@ -33,5 +34,5 @@ fun TextView.findWordForRightHanded(
         endIndex = str.length
     }
 
-    return str.substring(startIndex, endIndex)
+    return Span(startIndex, endIndex)
 }

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/ParagraphAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/ParagraphAdapter.kt
@@ -13,10 +13,9 @@ import androidx.recyclerview.widget.RecyclerView
 import com.guillermonegrete.tts.R
 import com.guillermonegrete.tts.databinding.ParagraphExpandedItemBinding
 import com.guillermonegrete.tts.databinding.ParagraphItemBinding
-import com.guillermonegrete.tts.db.Words
 
 class ParagraphAdapter(
-    val items: List<Words>,
+    val items: List<ParagraphItem>,
     val viewModel: WebReaderViewModel
 ): RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
@@ -41,6 +40,10 @@ class ParagraphAdapter(
 
     override fun getItemViewType(position: Int) = if(expandedItemPos == position) R.layout.paragraph_expanded_item else R.layout.paragraph_item
 
+    fun updateTranslation(translation: String){
+        items[expandedItemPos].translation = translation
+    }
+
     fun updateExpanded(){
         notifyItemChanged(expandedItemPos)
     }
@@ -60,8 +63,8 @@ class ParagraphAdapter(
             }
         }
 
-        fun bind(item: Words){
-            binding.paragraph.text = item.word
+        fun bind(item: ParagraphItem){
+            binding.paragraph.text = item.original
         }
 
     }
@@ -118,11 +121,11 @@ class ParagraphAdapter(
             }
         }
 
-        fun bind(item: Words){
-            binding.paragraph.text = item.word
+        fun bind(item: ParagraphItem){
+            binding.paragraph.text = item.original
             binding.loadingParagraph.isVisible = isLoading
             binding.translate.isVisible = !isLoading
-            binding.translatedParagraph.text = item.definition.ifBlank { noTranslationText }
+            binding.translatedParagraph.text = item.translation.ifBlank { noTranslationText }
         }
 
         private fun TextView.setHighlightedText(start: Int, end: Int){
@@ -167,4 +170,6 @@ class ParagraphAdapter(
         }
 
     }
+
+    data class ParagraphItem(val original: CharSequence, var translation: String = "")
 }

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -245,7 +245,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                         notesText.text = word.notes
                         moreInfoBtn.isGone = wordResult.isSentence
                         moreInfoBtn.setOnClickListener {
-                            viewModel.onWordClicked(word.word, adapter?.selectedSentence?.paragraphIndex ?: -1)
+                            viewModel.getLinksForWord(word.word, word.lang)
                         }
 
                         if(bottomSheetBehavior.state == BottomSheetBehavior.STATE_HIDDEN) bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -3,6 +3,7 @@ package com.guillermonegrete.tts.webreader
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.text.Html
+import android.util.Log
 import android.view.*
 import android.webkit.WebViewClient
 import android.widget.AdapterView
@@ -56,7 +57,10 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                 var isError = false
                 var isLoading = false
                 when(it){
-                    is LoadResult.Error -> isError = true
+                    is LoadResult.Error -> {
+                        Log.e(TAG, "Error loading page", it.exception)
+                        isError = true
+                    }
                     LoadResult.Loading -> isLoading = true
                     is LoadResult.Success -> setParagraphList(it.data)
                 }
@@ -250,6 +254,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                     }
                     is LoadResult.Error -> {
                         Toast.makeText(context, "Couldn't translate text", Toast.LENGTH_SHORT).show()
+                        Log.e(TAG, "Error translating selected text", result.exception)
                         true
                     }
                     LoadResult.Loading -> {
@@ -301,5 +306,9 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
         val bottomSheetBehavior = BottomSheetBehavior.from(binding.translationBottomSheet)
         webSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
         bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
+    }
+
+    companion object{
+        val TAG = this::class.simpleName
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -109,7 +109,14 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
             }
 
             translate.setOnClickListener {
-                val selected = adapter?.selectedSentence ?: return@setOnClickListener
+                val adapter = adapter ?: return@setOnClickListener
+                val expandedItemPos = adapter.expandedItemPos
+                if (expandedItemPos != -1) {
+                    viewModel.translateParagraph(expandedItemPos)
+                    return@setOnClickListener
+                }
+
+                val selected = adapter.selectedSentence
                 if(selected.paragraphIndex != -1 && selected.sentenceIndex != -1)
                     viewModel.translateSelected(selected.paragraphIndex, selected.sentenceIndex)
             }

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -105,7 +105,9 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
             }
 
             translate.setOnClickListener {
-                viewModel.translateSelected(adapter?.selectedSentenceText)
+                val selected = adapter?.selectedSentence ?: return@setOnClickListener
+                if(selected.paragraphIndex != -1 && selected.sentenceIndex != -1)
+                    viewModel.translateSelected(selected.paragraphIndex, selected.sentenceIndex)
             }
 
             retryButton.setOnClickListener {
@@ -128,8 +130,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                 val newParagraphs =  text.split("\n")
                     .map { HtmlCompat.fromHtml(it, Html.FROM_HTML_MODE_COMPACT).trim() }
                     .filter { it.isNotEmpty() }
-                viewModel.createParagraphs(newParagraphs)
-                val splitParagraphs = viewModel.splitBySentence(newParagraphs)
+                val splitParagraphs = viewModel.createParagraphs(newParagraphs)
                 val newAdapter = ParagraphAdapter(splitParagraphs.map { ParagraphAdapter.ParagraphItem(it.paragraph, it.indexes, it.sentences ) }, viewModel) {
                     hideBottomSheets()
                 }
@@ -243,6 +244,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                             viewModel.onWordClicked(word.word, adapter?.selectedSentence?.paragraphIndex ?: -1)
                         }
 
+                        if(bottomSheetBehavior.state == BottomSheetBehavior.STATE_HIDDEN) bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
                         menuBar.isVisible = false
                         true
                     }

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -130,13 +130,17 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                     .filter { it.isNotEmpty() }
                 viewModel.createParagraphs(newParagraphs)
                 val splitParagraphs = viewModel.splitBySentence(newParagraphs)
-                adapter = ParagraphAdapter(splitParagraphs.map { ParagraphAdapter.ParagraphItem(it.paragraph, it.indexes, it.sentences ) }, viewModel) {
+                val newAdapter = ParagraphAdapter(splitParagraphs.map { ParagraphAdapter.ParagraphItem(it.paragraph, it.indexes, it.sentences ) }, viewModel) {
                     hideBottomSheets()
                 }
+                setSentenceNavigator(newAdapter)
+                adapter = newAdapter
             }
             paragraphsList.adapter = adapter
 
             translate.isVisible = true
+            previousSelection.isVisible = true
+            nextSelection.isVisible = true
         }
     }
 
@@ -254,6 +258,22 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                         false
                     }
                 }
+            }
+        }
+    }
+
+    private fun setSentenceNavigator(newAdapter: ParagraphAdapter) {
+        with(binding){
+            previousSelection.setOnClickListener {
+                newAdapter.previousSentence()
+                val pos = newAdapter.selectedSentence.paragraphIndex
+                if(pos != -1) paragraphsList.smoothScrollToPosition(pos)
+            }
+
+            nextSelection.setOnClickListener {
+                newAdapter.nextSentence()
+                val pos = newAdapter.selectedSentence.paragraphIndex
+                if(pos != -1) paragraphsList.smoothScrollToPosition(pos)
             }
         }
     }

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -158,7 +158,8 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                         .map { HtmlCompat.fromHtml(it, Html.FROM_HTML_MODE_COMPACT).trim() }
                         .filter { it.isNotEmpty() }
                     viewModel.createParagraphs(newParagraphs)
-                    adapter = ParagraphAdapter(newParagraphs.map { ParagraphAdapter.ParagraphItem(it) }, viewModel)
+                    val splitParagraphs = viewModel.splitBySentence(newParagraphs)
+                    adapter = ParagraphAdapter(splitParagraphs.map { ParagraphAdapter.ParagraphItem(it.paragraph, it.indexes, it.sentences ) }, viewModel)
                 }
                 paragraphsList.adapter = adapter
             }

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -106,6 +106,10 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                 }
             }
 
+            translate.setOnClickListener {
+                viewModel.translateSelected(adapter?.selectedSentenceText)
+            }
+
             retryButton.setOnClickListener {
                 viewModel.loadDoc(args.link)
             }
@@ -129,6 +133,8 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                 adapter = ParagraphAdapter(splitParagraphs.map { ParagraphAdapter.ParagraphItem(it.paragraph, it.indexes, it.sentences ) }, viewModel)
             }
             paragraphsList.adapter = adapter
+
+            translate.isVisible = true
         }
     }
 
@@ -229,12 +235,13 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
             viewModel.textInfo.observe(viewLifecycleOwner) { result ->
                 barLoading.isInvisible = when(result){
                     is LoadResult.Success -> {
-                        val word = result.data.word
+                        val wordResult = result.data
+                        val word = wordResult.word
                         translatedText.text = word.definition
                         notesText.isGone = word.notes.isNullOrEmpty()
                         notesText.text = word.notes
-                        moreInfoBtn.isVisible = true
-                        moreInfoBtn.setOnClickListener { showTextDialog(word, result.data.isSaved) }
+                        moreInfoBtn.isGone = wordResult.isSentence
+                        moreInfoBtn.setOnClickListener { showTextDialog(word, wordResult.isSaved) }
 
                         menuBar.isVisible = false
                         true
@@ -244,6 +251,8 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                         true
                     }
                     LoadResult.Loading -> {
+                        translatedText.text = ""
+                        notesText.text = ""
                         bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
                         moreInfoBtn.isVisible = false
                         false

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -22,9 +22,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.guillermonegrete.tts.R
 import com.guillermonegrete.tts.data.LoadResult
 import com.guillermonegrete.tts.databinding.FragmentWebReaderBinding
-import com.guillermonegrete.tts.db.Words
 import com.guillermonegrete.tts.textprocessing.ExternalLinksAdapter
-import com.guillermonegrete.tts.textprocessing.TextInfoDialog
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -132,7 +130,9 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                     .filter { it.isNotEmpty() }
                 viewModel.createParagraphs(newParagraphs)
                 val splitParagraphs = viewModel.splitBySentence(newParagraphs)
-                adapter = ParagraphAdapter(splitParagraphs.map { ParagraphAdapter.ParagraphItem(it.paragraph, it.indexes, it.sentences ) }, viewModel)
+                adapter = ParagraphAdapter(splitParagraphs.map { ParagraphAdapter.ParagraphItem(it.paragraph, it.indexes, it.sentences ) }, viewModel) {
+                    hideBottomSheets()
+                }
             }
             paragraphsList.adapter = adapter
 
@@ -154,18 +154,6 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
 
             override fun onMenuItemSelected(menuItem: MenuItem) = false
         }, viewLifecycleOwner, Lifecycle.State.RESUMED)
-    }
-
-    private fun showTextDialog(words: Words, isSaved: Boolean){
-        // TODO try to add this as destination in jetpack navigation
-        val dialog = TextInfoDialog.newInstance(
-            words.word,
-            TextInfoDialog.NO_SERVICE,
-            words,
-            languageFrom = languageFrom,
-            wordIsSaved = isSaved
-        )
-        dialog.show(childFragmentManager, "Text_info")
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -227,10 +215,12 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
             val bottomSheetBehavior = BottomSheetBehavior.from(translationBottomSheet)
             bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
 
-            bottomSheetBehavior.addBottomSheetCallback(object :
-                BottomSheetBehavior.BottomSheetCallback() {
+            bottomSheetBehavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
                 override fun onStateChanged(bottomSheet: View, newState: Int) {
-                    if (newState == BottomSheetBehavior.STATE_HIDDEN) menuBar.isVisible = true
+                    if (newState == BottomSheetBehavior.STATE_HIDDEN) {
+                        adapter?.unselectWord()
+                        menuBar.isVisible = true
+                    }
                 }
 
                 override fun onSlide(bottomSheet: View, slideOffset: Float) {}
@@ -282,5 +272,12 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                 }
             }
         }
+    }
+
+    private fun hideBottomSheets() {
+        val webSheetBehavior = BottomSheetBehavior.from(binding.bottomSheet)
+        val bottomSheetBehavior = BottomSheetBehavior.from(binding.translationBottomSheet)
+        webSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
+        bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
@@ -202,6 +202,10 @@ class WebReaderViewModel @Inject constructor(
         // first try to get the language from a translation, if not from the set language, else ignore.
         val lang = translatedParagraphs.getOrNull(pos)?.src ?: cacheWebLink?.language ?: return
 
+        getLinksForWord(word, lang)
+    }
+
+    fun getLinksForWord(word: String, lang: String) {
         viewModelScope.launch {
             val links = withContext(Dispatchers.IO) { getExternalLinksInteractor(lang) }
             _clickedWord.value = WordAndLinks(word, links)

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
@@ -5,7 +5,7 @@ import com.guillermonegrete.tts.common.models.Span
 import com.guillermonegrete.tts.data.LoadResult
 import com.guillermonegrete.tts.data.Result
 import com.guillermonegrete.tts.data.Translation
-import com.guillermonegrete.tts.data.source.WordRepository
+import com.guillermonegrete.tts.data.source.WordRepositorySource
 import com.guillermonegrete.tts.db.WebLink
 import com.guillermonegrete.tts.db.WebLinkDAO
 import com.guillermonegrete.tts.db.Words
@@ -31,7 +31,7 @@ import javax.inject.Inject
 class WebReaderViewModel @Inject constructor(
     private val getTranslationInteractor: GetLangAndTranslation,
     private val getExternalLinksInteractor: GetExternalLink,
-    private val wordRepository: WordRepository,
+    private val wordRepository: WordRepositorySource,
     private val webLinkDAO: WebLinkDAO,
 ): ViewModel() {
 

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
@@ -166,7 +166,7 @@ class WebReaderViewModel @Inject constructor(
 
         when(result){
             is Result.Success -> onResult(result.data)
-            is Result.Error -> _translatedParagraph.value = LoadResult.Error(result.exception)
+            is Result.Error -> _textInfo.value = LoadResult.Error(result.exception)
         }
     }
 

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
@@ -198,7 +198,7 @@ class WebReaderViewModel @Inject constructor(
     fun onWordClicked(word: String, pos: Int) {
 
         // first try to get the language from a translation, if not from the set language, else ignore.
-        val lang = translatedParagraphs[pos]?.src ?: cacheWebLink?.language ?: return
+        val lang = translatedParagraphs.getOrNull(pos)?.src ?: cacheWebLink?.language ?: return
 
         viewModelScope.launch {
             val links = withContext(Dispatchers.IO) { getExternalLinksInteractor(lang) }

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
@@ -40,7 +40,7 @@ class WebReaderViewModel @Inject constructor(
     private var cachedParagraphs: List<Words>? = null
 
     private var _translatedParagraphs = mutableListOf<Translation?>()
-    private val translatedParagraphs: List<Translation?>
+    val translatedParagraphs: List<Translation?>
         get() = _translatedParagraphs
 
     private val _translatedParagraph = MutableLiveData<LoadResult<Int>>()
@@ -96,8 +96,8 @@ class WebReaderViewModel @Inject constructor(
         }
     }
 
-    fun createParagraphs(text: String): List<Words> {
-        val newParagraphs = cachedParagraphs ?: text.split("\n").map { Words(it, "", "") }
+    fun createParagraphs(paragraphs: List<CharSequence>): List<Words> {
+        val newParagraphs = cachedParagraphs ?: paragraphs.map { Words(it.toString(), "", "") }
         if(cachedParagraphs == null) {
             cachedParagraphs = newParagraphs
             _translatedParagraphs = arrayOfNulls<Translation>(newParagraphs.size).toMutableList()

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
@@ -82,13 +82,17 @@ class WebReaderViewModel @Inject constructor(
     }
 
     private suspend fun getPage(url: String): String = withContext(ioDispatcher){
-        val doc = Jsoup.connect(url).get()
-        doc.body().select("menu, header, footer, logo, nav, search, link, button, btn, ad, script, style, img").remove()
-        // Removes empty tags (e.g. <div></div>) and keeps self closing tags e.g. <br/>
-        for (element in doc.select("*")) {
-            if (!element.hasText() && element.isBlock) element.remove()
+        val result = runCatching {
+            val doc = Jsoup.connect(url).get()
+            doc.body().select("menu, header, footer, logo, nav, search, link, button, btn, ad, script, style, img").remove()
+            // Removes empty tags (e.g. <div></div>) and keeps self closing tags e.g. <br/>
+            for (element in doc.select("*")) {
+                if (!element.hasText() && element.isBlock) element.remove()
+            }
+            doc.body().html()
         }
-        doc.body().html()
+
+        return@withContext result.getOrThrow()
     }
 
     fun saveWebLink(){

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/model/SplitParagraph.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/model/SplitParagraph.kt
@@ -1,0 +1,12 @@
+package com.guillermonegrete.tts.webreader.model
+
+import com.guillermonegrete.tts.common.models.Span
+
+data class SplitParagraph(
+    val paragraph: CharSequence,
+    /**
+     * The start and end indexes for each sentence in the paragraph
+     */
+    val indexes: List<Span>,
+    val sentences: List<String>
+)

--- a/app/src/main/res/drawable/ic_baseline_arrow_back_ios_new_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_arrow_back_ios_new_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M17.77,3.77l-1.77,-1.77l-10,10l10,10l1.77,-1.77l-8.23,-8.23z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_arrow_forward_ios_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_arrow_forward_ios_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M6.23,20.23l1.77,1.77l10,-10l-10,-10l-1.77,1.77l8.23,8.23z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_close_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_close_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_web_reader.xml
+++ b/app/src/main/res/layout/fragment_web_reader.xml
@@ -21,6 +21,8 @@
             android:id="@+id/paragraphs_list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:paddingBottom="48dp"
+            android:clipToPadding="false"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listitem="@layout/paragraph_item"/>
 
@@ -61,13 +63,13 @@
 
         </LinearLayout>
 
-        <FrameLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/menu_bar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
             android:background="?colorPrimary"
-            app:layout_behavior="com.google.android.material.behavior.HideBottomViewOnScrollBehavior"
-            android:layout_gravity="bottom">
+            app:layout_behavior="com.google.android.material.behavior.HideBottomViewOnScrollBehavior">
 
             <ImageButton
                 android:id="@+id/translate"
@@ -79,7 +81,42 @@
                 android:contentDescription="@string/toggle"
                 android:tint="?colorOnPrimarySurface"
                 android:visibility="invisible"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_translate_black_24dp"
+                tools:visibility="visible" />
+
+            <ImageButton
+                android:id="@+id/previous_selection"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="8dp"
+                android:background="?android:selectableItemBackgroundBorderless"
+                android:contentDescription="@string/previous_selection"
+                android:tint="?colorOnPrimarySurface"
+                android:visibility="invisible"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/translate"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/ic_baseline_arrow_back_ios_new_24"
+                tools:visibility="visible" />
+
+            <ImageButton
+                android:id="@+id/next_selection"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="8dp"
+                android:background="?android:selectableItemBackgroundBorderless"
+                android:contentDescription="@string/next_selection"
+                android:tint="?colorOnPrimarySurface"
+                android:visibility="invisible"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/previous_selection"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/ic_baseline_arrow_forward_ios_24"
                 tools:visibility="visible" />
 
             <Spinner
@@ -89,9 +126,12 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
                 android:spinnerMode="dialog"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
                 tools:listitem="@android:layout/simple_list_item_1" />
 
-        </FrameLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/translation_bottom_sheet"

--- a/app/src/main/res/layout/fragment_web_reader.xml
+++ b/app/src/main/res/layout/fragment_web_reader.xml
@@ -17,25 +17,12 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.core.widget.NestedScrollView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <TextView
-                android:id="@+id/body_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:layout_margin="@dimen/text_margin"
-                tools:text="@string/large_text"/>
-        </androidx.core.widget.NestedScrollView>
-
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/paragraphs_list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:visibility="gone"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            tools:listitem="@layout/paragraph_item"/>
 
         <LinearLayout
             android:id="@+id/bottom_sheet"
@@ -81,20 +68,6 @@
             app:layout_behavior="com.google.android.material.behavior.HideBottomViewOnScrollBehavior"
             android:layout_gravity="bottom">
 
-            <ImageButton
-                android:id="@+id/list_toggle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginStart="8dp"
-                android:background="?android:selectableItemBackgroundBorderless"
-                android:contentDescription="@string/toggle"
-                android:minWidth="48dp"
-                android:minHeight="48dp"
-                android:tint="?colorOnPrimarySurface"
-                android:visibility="invisible"
-                app:srcCompat="@drawable/ic_list_grey_24dp"
-                tools:visibility="visible" />
             <Spinner
                 android:id="@+id/set_language"
                 style="@android:style/Widget.Material.Spinner"

--- a/app/src/main/res/layout/fragment_web_reader.xml
+++ b/app/src/main/res/layout/fragment_web_reader.xml
@@ -68,6 +68,19 @@
             app:layout_behavior="com.google.android.material.behavior.HideBottomViewOnScrollBehavior"
             android:layout_gravity="bottom">
 
+            <ImageButton
+                android:id="@+id/translate"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="8dp"
+                android:background="?android:selectableItemBackgroundBorderless"
+                android:contentDescription="@string/toggle"
+                android:tint="?colorOnPrimarySurface"
+                android:visibility="invisible"
+                app:srcCompat="@drawable/ic_translate_black_24dp"
+                tools:visibility="visible" />
+
             <Spinner
                 android:id="@+id/set_language"
                 style="@android:style/Widget.Material.Spinner"

--- a/app/src/main/res/layout/fragment_web_reader.xml
+++ b/app/src/main/res/layout/fragment_web_reader.xml
@@ -29,6 +29,7 @@
             android:layout_width="match_parent"
             android:layout_height="350dp"
             android:orientation="vertical"
+            android:elevation="2dp"
             app:behavior_hideable="true"
             app:behavior_skipCollapsed="true"
             app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">

--- a/app/src/main/res/layout/paragraph_expanded_item.xml
+++ b/app/src/main/res/layout/paragraph_expanded_item.xml
@@ -36,7 +36,7 @@
             android:layout_width="48dp"
             android:layout_height="48dp"
             android:contentDescription="@string/expand"
-            app:icon="@drawable/ic_baseline_arrow_drop_down_24"
+            app:icon="@drawable/ic_baseline_close_24"
             app:iconGravity="textStart"
             app:iconPadding="0dp"
             app:iconTint="?colorOnSurface"
@@ -57,20 +57,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/paragraph"
             tools:text="Maecenas bibendum nibh elit, nec elementum augue scelerisque nec. Integer ut commodo urna, vel congue purus. Ut tincidunt augue vel semper volutpat. Nulla facilisi. Ut pretium lobortis velit nec lobortis. Aenean in pellentesque dolor, eget pellentesque justo. Donec vehicula nec nibh vitae viverra. Aenean et lorem ac est posuere porta sed et est. Integer ullamcorper elit neque, vitae cursus augue cursus a. Phasellus fermentum nisi sit amet tortor maximus, non facilisis enim laoreet. Nullam interdum, eros at dignissim dictum, tellus tellus rutrum dui, vitae porta urna mi sit amet sapien. Ut aliquet mollis tortor, ut consequat quam ornare sed. " />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/translate"
-            style="@style/Widget.MaterialComponents.Button.TextButton"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:contentDescription="@string/translate_description"
-            app:icon="@drawable/ic_translate_black_24dp"
-            app:iconGravity="textStart"
-            app:iconPadding="0dp"
-            app:iconTint="?colorOnSurface"
-            app:layout_constraintBottom_toBottomOf="@id/toggle_paragraph"
-            app:layout_constraintEnd_toStartOf="@+id/toggle_paragraph"
-            app:layout_constraintTop_toTopOf="@+id/toggle_paragraph" />
 
         <ProgressBar
             android:id="@+id/loadingParagraph"

--- a/app/src/main/res/layout/paragraph_item.xml
+++ b/app/src/main/res/layout/paragraph_item.xml
@@ -5,14 +5,11 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-
     <TextView
         android:id="@+id/paragraph"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="8dp"
-        android:paddingBottom="8dp"
         android:textAppearance="@style/TextAppearance.AppCompat.Medium"
         app:layout_constraintEnd_toStartOf="@+id/toggle_paragraph"
         app:layout_constraintStart_toStartOf="parent"
@@ -27,7 +24,7 @@
         android:background="?selectableItemBackgroundBorderless"
         android:tint="@color/DarkGray"
         app:srcCompat="@drawable/ic_baseline_arrow_left_24"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/paragraph"
         app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/paragraph_item.xml
+++ b/app/src/main/res/layout/paragraph_item.xml
@@ -1,30 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/paragraph"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
-
-    <TextView
-        android:id="@+id/paragraph"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-        app:layout_constraintEnd_toStartOf="@+id/toggle_paragraph"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />
-
-    <ImageButton
-        android:id="@+id/toggle_paragraph"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
-        android:contentDescription="@string/expand"
-        android:background="?selectableItemBackgroundBorderless"
-        android:tint="@color/DarkGray"
-        app:srcCompat="@drawable/ic_baseline_arrow_left_24"
-        app:layout_constraintBottom_toBottomOf="@id/paragraph"
-        app:layout_constraintEnd_toEndOf="parent" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="16dp"
+    android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -197,5 +197,7 @@
     <string name="dialog">Dialog</string>
     <string name="refresh">Refresh</string>
     <string name="loading_page_error_msg">Error loading page</string>
+    <string name="previous_selection">previous selection</string>
+    <string name="next_selection">next selection</string>
 
 </resources>

--- a/app/src/test/java/com/guillermonegrete/tts/MainCoroutineRule.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/MainCoroutineRule.kt
@@ -19,9 +19,7 @@ package com.guillermonegrete.tts
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.*
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 import kotlin.coroutines.ContinuationInterceptor
@@ -61,4 +59,19 @@ class MainCoroutineRule : TestWatcher(), TestCoroutineScope by TestCoroutineScop
         super.finished(description)
         Dispatchers.resetMain()
     }
+}
+
+@ExperimentalCoroutinesApi
+class MainDispatcherRule(val dispatcher: TestDispatcher = StandardTestDispatcher()): TestWatcher() {
+
+    override fun starting(description: Description?) {
+        super.starting(description)
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description?) {
+        super.finished(description)
+        Dispatchers.resetMain()
+    }
+
 }

--- a/app/src/test/java/com/guillermonegrete/tts/data/preferences/FakeSettingsRepository.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/data/preferences/FakeSettingsRepository.kt
@@ -1,5 +1,7 @@
 package com.guillermonegrete.tts.data.preferences
 
+import kotlinx.coroutines.flow.Flow
+
 class FakeSettingsRepository: SettingsRepository {
 
     override fun setLanguageTo(language: String) {
@@ -16,5 +18,13 @@ class FakeSettingsRepository: SettingsRepository {
 
     override fun getLanguageFrom(): String {
         return "auto"
+    }
+
+    override fun getImportTabPosition(): Flow<Int> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun setImportTabPosition(pos: Int) {
+        TODO("Not yet implemented")
     }
 }

--- a/app/src/test/java/com/guillermonegrete/tts/data/source/FakeWordRepository.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/data/source/FakeWordRepository.kt
@@ -1,0 +1,128 @@
+package com.guillermonegrete.tts.data.source
+
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.guillermonegrete.tts.data.Result
+import com.guillermonegrete.tts.data.Translation
+import com.guillermonegrete.tts.db.Words
+import java.lang.Exception
+import java.util.LinkedHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FakeWordRepository @Inject constructor(): WordRepositorySource {
+
+    var wordsServiceData: LinkedHashMap<String, Words> = LinkedHashMap()
+    var remoteWordServiceData: LinkedHashMap<String, Words> = LinkedHashMap()
+
+    var translationsWordData: LinkedHashMap<String, Words> = LinkedHashMap()
+    var translationsData: LinkedHashMap<String, Translation> = LinkedHashMap()
+
+    var languagesData: MutableSet<String> = mutableSetOf()
+
+    override fun getWords(): MutableList<Words> {
+        return wordsServiceData.values.toMutableList()
+    }
+
+    override fun getWordsStream(): LiveData<MutableList<Words>> {
+        return MutableLiveData(wordsServiceData.values.toMutableList())
+    }
+
+    override fun getLocalWord(word: String, language: String): LiveData<Words> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getLanguagesISO(): MutableList<String> {
+        return languagesData.toMutableList()
+    }
+
+    override fun getWordLanguageInfo(
+        wordText: String,
+        languageFrom: String,
+        languageTo: String,
+        callback: WordRepositorySource.GetWordRepositoryCallback
+    ) {
+
+        val localWord = wordsServiceData[wordText]
+        if(localWord != null){
+            callback.onLocalWordLoaded(localWord)
+        } else {
+            callback.onLocalWordNotAvailable()
+
+            val remoteWord = remoteWordServiceData[wordText]
+            if(remoteWord != null) callback.onRemoteWordLoaded(remoteWord)
+            else callback.onDataNotAvailable(Words(wordText, "un", "un"))
+        }
+    }
+
+    override fun getLanguageAndTranslation(text: String, callback: WordRepositorySource.GetTranslationCallback) {
+        getLanguageAndTranslation(text, "auto", "en", callback)
+    }
+
+    override fun getLanguageAndTranslation(
+        text: String,
+        languageFrom: String,
+        languageTo: String,
+        callback: WordRepositorySource.GetTranslationCallback
+    ) {
+        val translation = translationsWordData[text]
+        if(translation != null) callback.onTranslationAndLanguage(translation)
+        else callback.onDataNotAvailable()
+    }
+
+    override fun getTranslation(
+        text: String,
+        languageFrom: String,
+        languageTo: String
+    ): Result<Translation> {
+        val word = translationsData[text] ?: return Result.Error(Exception("Translation not found"))
+        return Result.Success(word)
+    }
+
+    override fun deleteWord(word: String?) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun deleteWord(word: Words?) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun delete(vararg words: Words?) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun insert(vararg words: Words?) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    @VisibleForTesting
+    fun addWords(vararg words: Words) {
+        for (word in words) {
+            wordsServiceData[word.word] = word
+            languagesData.add(word.lang)
+        }
+    }
+
+    @VisibleForTesting
+    fun addRemoteWords(vararg words: Words) {
+        for (word in words) {
+            remoteWordServiceData[word.word] = word
+        }
+    }
+
+    @VisibleForTesting
+    fun addTranslation(vararg words: Words) {
+        for (word in words) {
+            translationsWordData[word.word] = word
+        }
+    }
+
+    @VisibleForTesting
+    fun addTranslation(vararg translations: Translation) {
+        for (translation in translations) {
+            translationsData[translation.sentences.first().orig] = translation
+        }
+    }
+}

--- a/app/src/test/java/com/guillermonegrete/tts/data/source/local/FakeExternalLinkSource.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/data/source/local/FakeExternalLinkSource.kt
@@ -1,0 +1,14 @@
+package com.guillermonegrete.tts.data.source.local
+
+import com.guillermonegrete.tts.data.source.ExternalLinksDataSource
+import com.guillermonegrete.tts.db.ExternalLink
+
+class FakeExternalLinkSource: ExternalLinksDataSource {
+    override fun getLanguageLinks(language: String, callback: ExternalLinksDataSource.Callback) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getLanguageLinks(language: String): List<ExternalLink> {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/test/java/com/guillermonegrete/tts/data/source/remote/FakeWordDataSource.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/data/source/remote/FakeWordDataSource.kt
@@ -48,6 +48,10 @@ class FakeWordDataSource: WordDataSource {
         return translationsData[wordText] ?: throw Exception("Not found")
     }
 
+    override fun loadWord(word: String?, language: String?): LiveData<Words> {
+        TODO("Not yet implemented")
+    }
+
     @VisibleForTesting
     fun addTranslation(vararg words: Words) {
         for (word in words) {

--- a/app/src/test/java/com/guillermonegrete/tts/db/FakeWebLinkDAO.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/db/FakeWebLinkDAO.kt
@@ -3,8 +3,12 @@ package com.guillermonegrete.tts.db
 import kotlinx.coroutines.flow.Flow
 
 class FakeWebLinkDAO: WebLinkDAO {
+
+    private val links = mutableListOf<WebLink>()
+
     override fun insert(link: WebLink): Long {
-        TODO("Not yet implemented")
+        links.add(link)
+        return link.id.toLong()
     }
 
     override fun update(link: WebLink) {
@@ -19,7 +23,5 @@ class FakeWebLinkDAO: WebLinkDAO {
         TODO("Not yet implemented")
     }
 
-    override suspend fun getLink(url: String): WebLink? {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getLink(url: String) = links.firstOrNull { it.url == url }
 }

--- a/app/src/test/java/com/guillermonegrete/tts/db/FakeWebLinkDAO.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/db/FakeWebLinkDAO.kt
@@ -1,0 +1,25 @@
+package com.guillermonegrete.tts.db
+
+import kotlinx.coroutines.flow.Flow
+
+class FakeWebLinkDAO: WebLinkDAO {
+    override fun insert(link: WebLink): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun update(link: WebLink) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun delete(link: WebLink) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRecentLinks(): Flow<List<WebLink>> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getLink(url: String): WebLink? {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/test/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModelTest.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModelTest.kt
@@ -16,6 +16,8 @@ import com.guillermonegrete.tts.main.domain.interactors.GetLangAndTranslation
 import com.guillermonegrete.tts.threading.TestMainThread
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.pauseDispatcher
+import kotlinx.coroutines.test.resumeDispatcher
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/guillermonegrete/tts/webreader/WebReaderViewModelTest.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/webreader/WebReaderViewModelTest.kt
@@ -1,0 +1,68 @@
+package com.guillermonegrete.tts.webreader
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.guillermonegrete.tts.MainCoroutineRule
+import com.guillermonegrete.tts.MainDispatcherRule
+import com.guillermonegrete.tts.TestThreadExecutor
+import com.guillermonegrete.tts.data.LoadResult
+import com.guillermonegrete.tts.data.source.ExternalLinksDataSource
+import com.guillermonegrete.tts.data.source.FakeWordRepository
+import com.guillermonegrete.tts.data.source.local.FakeExternalLinkSource
+import com.guillermonegrete.tts.db.FakeWebLinkDAO
+import com.guillermonegrete.tts.getOrAwaitValue
+import com.guillermonegrete.tts.main.domain.interactors.GetLangAndTranslation
+import com.guillermonegrete.tts.textprocessing.domain.interactors.GetExternalLink
+import com.guillermonegrete.tts.threading.TestMainThread
+import io.mockk.every
+import io.mockk.mockkStatic
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class WebReaderViewModelTest {
+
+    /*@ExperimentalCoroutinesApi
+    @get:Rule
+    var mainCoroutineRule = MainCoroutineRule()*/
+    @ExperimentalCoroutinesApi
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @get:Rule
+    var instantExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var viewModel: WebReaderViewModel
+
+    private lateinit var wordRepository: FakeWordRepository
+    private lateinit var externalLinksSource: ExternalLinksDataSource
+    private lateinit var webLinkDAO: FakeWebLinkDAO
+
+    @Before
+    fun setup(){
+        wordRepository = FakeWordRepository()
+        val getTranslationInteractor = GetLangAndTranslation(TestThreadExecutor(), TestMainThread(), wordRepository)
+
+        externalLinksSource = FakeExternalLinkSource()
+        val getExternalLink = GetExternalLink(TestThreadExecutor(), TestMainThread(), externalLinksSource)
+
+        webLinkDAO = FakeWebLinkDAO()
+        viewModel = WebReaderViewModel(getTranslationInteractor, getExternalLink, wordRepository, webLinkDAO)
+
+        mockkStatic(Jsoup::class)
+    }
+
+    @Test
+    fun `Given valid url, when load page, then load success`() = runTest{
+        val url = "https://example.com"
+        every { Jsoup.connect(url).get() } returns Document(url)
+        viewModel.loadDoc(url)
+
+        assertEquals(LoadResult.Success("Page content"), viewModel.page.getOrAwaitValue())
+
+    }
+}


### PR DESCRIPTION
Closes #89. Long press a sentence to highlight it.

Also combined the two layouts (the regular single text and the paragraph list) into one while keeping the features of both. This makes the layout cleaner.

- Removed the buttons to expand a paragraph, now it's done double tapping the paragraph.
- Removed button to translate paragraph. Use the button in the bar instead.