### PR TITLE
Update LeakCanary to fix missing exported value in manifest

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -182,7 +182,7 @@ dependencies {
     lintChecks "com.google.dagger:dagger-lint-aar:$dagger_version"
 
     // LeakCanary
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.5'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.7'
 
     // Jsoup HTML parser
     implementation 'org.jsoup:jsoup:1.13.1'


### PR DESCRIPTION
Updated fix canary to 2.7 version that adds the exported value for the leak activity in the manifest. This value must be explicitly set for apps targeting API 31 and above.