### PR TITLE
Bugfix/#124 incorrect screen area

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/customviews/SnippingView.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/customviews/SnippingView.kt
@@ -58,6 +58,7 @@ class SnippingView : View {
     }
 
     private fun setBitmaps(context: Context) {
+        // Screen dimensions without the navigation bar because we don't draw over it
         wParent = context.resources.displayMetrics.widthPixels
         hParent = context.resources.displayMetrics.heightPixels
 

--- a/app/src/main/java/com/guillermonegrete/tts/imageprocessing/ScreenImageCaptor.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/imageprocessing/ScreenImageCaptor.kt
@@ -8,7 +8,6 @@ import android.media.ImageReader
 import android.media.projection.MediaProjection
 import android.media.projection.MediaProjectionManager
 import android.os.Handler
-import android.os.Looper
 import android.util.DisplayMetrics
 
 /*
@@ -104,7 +103,7 @@ class ScreenImageCaptor(
             DisplayManager.VIRTUAL_DISPLAY_FLAG_OWN_CONTENT_ONLY or DisplayManager.VIRTUAL_DISPLAY_FLAG_PUBLIC
     }
 
-    interface Callback{
+    fun interface Callback{
         fun onImageCaptured(image: Bitmap)
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/imageprocessing/domain/interactors/DetectTextFromScreen.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/imageprocessing/domain/interactors/DetectTextFromScreen.kt
@@ -1,6 +1,5 @@
 package com.guillermonegrete.tts.imageprocessing.domain.interactors
 
-import android.graphics.Bitmap
 import android.graphics.Rect
 import com.guillermonegrete.tts.AbstractInteractor
 import com.guillermonegrete.tts.MainThread
@@ -12,7 +11,7 @@ import javax.inject.Inject
 class DetectTextFromScreen @Inject constructor (
     executor: ExecutorService,
     mainThread: MainThread,
-    private val imageProcessor: ImageProcessingSource
+    private val imageProcessor: ImageProcessingSource,
 ): AbstractInteractor(executor, mainThread) {
 
     private var screenCaptor: ScreenImageCaptor? = null

--- a/app/src/main/java/com/guillermonegrete/tts/imageprocessing/domain/interactors/DetectTextFromScreen.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/imageprocessing/domain/interactors/DetectTextFromScreen.kt
@@ -31,11 +31,9 @@ class DetectTextFromScreen @Inject constructor (
     }
 
     override fun run() {
-        screenCaptor?.getImage(areaRect, object : ScreenImageCaptor.Callback{
-            override fun onImageCaptured(image: Bitmap) {
-                imageProcessor.detectText(image, imageProcessorCallback)
-            }
-        })
+        screenCaptor?.getImage(areaRect) { image ->
+            imageProcessor.detectText(image, imageProcessorCallback)
+        }
     }
 
     private val imageProcessorCallback = object: ImageProcessingSource.Callback{

--- a/app/src/main/java/com/guillermonegrete/tts/services/ScreenTextService.java
+++ b/app/src/main/java/com/guillermonegrete/tts/services/ScreenTextService.java
@@ -142,7 +142,7 @@ public class ScreenTextService extends Service {
         gestureDetector = new GestureDetector(this, new SingleTapConfirm());
 
         screenSize = new Point();
-        windowManager.getDefaultDisplay().getSize(screenSize);
+        windowManager.getDefaultDisplay().getRealSize(screenSize);
 
         windowParams = new WindowManager.LayoutParams();
         mParamsTrash = new WindowManager.LayoutParams();


### PR DESCRIPTION
Closes #124. The issue was with devices that have no physical navigation bar.  It was using the screen height without the bar height for generating the screenshot, which made the image height distorted and gave the incorrect screen cropped area.