### PR TITLE
Pr/add compose UI

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,13 @@ android {
 
     buildFeatures {
         viewBinding true
+        compose true
     }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.3.1'
+    }
+
     namespace 'com.guillermonegrete.tts'
 
 }
@@ -94,6 +100,23 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
     implementation 'com.google.android.material:material:1.3.0'
     implementation "androidx.datastore:datastore-preferences:1.0.0"
+
+    // Compose
+    def composeBom = platform('androidx.compose:compose-bom:2023.01.00')
+    implementation composeBom
+    androidTestImplementation composeBom
+
+    implementation 'androidx.compose.material:material'
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.activity:activity-compose:1.6.1'
+
+    // Android Studio Preview support
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+
+    // UI Tests
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest'
 
     // fragments
     def fragment_version = "1.5.0" // Newest versions cause a memory leak, update when fixed.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,7 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace 'com.guillermonegrete.tts'
 
 }
 
@@ -151,7 +152,7 @@ dependencies {
     androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     // Navigation component
-    def nav_version = "2.5.0"
+    def nav_version = "2.5.3"
     // Java language implementation
     implementation "androidx.navigation:navigation-fragment:$nav_version"
     implementation "androidx.navigation:navigation-ui:$nav_version"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.guillermonegrete.tts">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:networkSecurityConfig="@xml/network_security_config">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.guillermonegrete.tts" >
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>

--- a/build.gradle
+++ b/build.gradle
@@ -7,12 +7,11 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath 'com.google.gms:google-services:4.3.15'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.44'
-        def nav_version = '2.4.1'
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3"
 
         // Crashlytics plugin
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.4'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip


### PR DESCRIPTION
Enabled Compose UI. From now on all new layouts and UI components should be done using Compose.
For older classes, there are ways to [add compose to view hierarchies](https://developer.android.com/jetpack/compose/migrate/interoperability-apis/compose-in-views) or if the layouts are simple they can be rewritten entirely in Compose.