### PR TITLE
Minor fixes/improvements for the translation sheet.

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -642,6 +642,8 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                     updateBottomPadding(root.height)
                 }
             }
+            val padding = if (isVisible) 0 else resources.getDimensionPixelSize(R.dimen.default_dialog_padding)
+            constraintLayout.updatePadding(bottom = padding)
         }
     }
 

--- a/app/src/main/res/layout/translation_card.xml
+++ b/app/src/main/res/layout/translation_card.xml
@@ -6,7 +6,7 @@
     android:id="@+id/translation_bottom_sheet"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginHorizontal="16dp"
+    android:layout_marginHorizontal="8dp"
     app:strokeColor="?colorOnSurface"
     app:strokeWidth="1dp"
     app:behavior_hideable="true"
@@ -14,6 +14,7 @@
     app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/constraint_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="?colorSurface"
@@ -65,6 +66,7 @@
             app:layout_constraintVertical_bias="0.0"
             app:layout_constraintVertical_chainStyle="packed"
             app:layout_constrainedHeight="true"
+            app:layout_goneMarginEnd="16dp"
             tools:text="A secondary color provides more ways to accent and distinguish your product. Having a secondary color is optional, and should be applied sparingly to accent select parts of your UI." />
 
         <TextView
@@ -109,12 +111,11 @@
             android:id="@+id/add_word_note_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:background="?android:selectableItemBackgroundBorderless"
+            android:background="?android:selectableItemBackground"
             android:contentDescription="@string/add_note_for_word"
             android:minWidth="48dp"
             android:minHeight="48dp"
             android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@+id/word_translation"
             app:layout_constraintEnd_toStartOf="@id/more_info_word_btn"
             app:layout_constraintTop_toBottomOf="@+id/top_border_word_view"
             app:tint="?colorOnSurface"
@@ -125,12 +126,11 @@
             android:id="@+id/more_info_word_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:background="?android:selectableItemBackgroundBorderless"
+            android:background="?android:selectableItemBackground"
             android:contentDescription="@string/more_information_word"
             android:minWidth="48dp"
             android:minHeight="48dp"
             android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@+id/word_translation"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/top_border_word_view"
             app:tint="?colorOnSurface"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -11,4 +11,6 @@
     <dimen name="text_size_medium">18sp</dimen>
     <dimen name="text_size_large">22sp</dimen>
     <dimen name="text_margin">16dp</dimen>
+
+    <dimen name="default_dialog_padding">16dp</dimen>
 </resources>


### PR DESCRIPTION
The word icons ripple stays within bounds, looks better like this. For the big dialog, the translation TextView has an end margin now so it doesn't touch the sheet border. The sheet's bottom padding is removed for the big dialog. The card's horizontal margin is smaller.