### PR TITLE
Bugfix/#178 notes issues

### DIFF
--- a/app/src/androidTest/java/com/guillermonegrete/tts/utils/EspressoUtils.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/tts/utils/EspressoUtils.kt
@@ -62,6 +62,31 @@ fun clickIn(x: Int, y: Int): ViewAction {
 }
 
 /**
+ * Performs a click in the given percentage coordinates
+ */
+fun clickPercent(pctX: Float, pctY: Float): ViewAction {
+    return GeneralClickAction(
+        Tap.SINGLE,
+        { view ->
+            val screenPos = IntArray(2)
+            view.getLocationOnScreen(screenPos)
+            val w = view.width
+            val h = view.height
+
+            val x = w * pctX
+            val y = h * pctY
+
+            val screenX = screenPos[0] + x
+            val screenY = screenPos[1] + y
+
+            floatArrayOf(screenX, screenY)
+        },
+        Press.FINGER,
+        InputDevice.SOURCE_MOUSE,
+        MotionEvent.BUTTON_PRIMARY)
+}
+
+/**
  * Taken from: https://stackoverflow.com/a/34795431/10244759
  */
 fun atPosition(position: Int, itemMatcher: Matcher<View?>): Matcher<View?> {
@@ -90,6 +115,8 @@ fun withBackgroundSpan(color: Int, start: Int, end: Int): Matcher<View?> {
 
         override fun describeTo(description: Description) {
             description.appendText("with background color span: ").appendValue(span.backgroundColor)
+                .appendText(" at position start: ").appendValue(start)
+                .appendText(" and end: ").appendValue(end)
         }
 
         override fun matchesSafely(foundView: TextView): Boolean {

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/ParagraphAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/ParagraphAdapter.kt
@@ -195,7 +195,7 @@ class ParagraphAdapter(
                     val span = clickedNote.span
                     val text = item.original.substring(span.start, span.end)
                     val absoluteSpan = Span(firstCharIndex + span.start, firstCharIndex + span.end)
-                    _addNoteClicked.tryEmit(EditNote(text, clickedNote.text, absoluteSpan, clickedNote.color, clickedNote.id))
+                    _addNoteClicked.tryEmit(EditNote(text, clickedNote.text, absoluteSpan, clickedNote.color, true, clickedNote.id))
                     return true
                 }
 
@@ -374,7 +374,7 @@ class ParagraphAdapter(
                         val span = Span(firstCharIndex + binding.paragraph.selectionStart, firstCharIndex + binding.paragraph.selectionEnd)
                         // New note so the text and color are empty and id is zero
                         val text = highlightedTextView?.getSelectedText().toString()
-                        _addNoteClicked.tryEmit(EditNote(text, "", span, 0, 0))
+                        _addNoteClicked.tryEmit(EditNote(text, "", span, 0, false, 0))
                         mode?.finish()
                         true
                     }
@@ -710,6 +710,7 @@ class ParagraphAdapter(
         val noteText: String,
         val span: Span,
         @ColorInt val color: Int,
+        val noteSaved: Boolean,
         val id: Long
     )
 

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -152,6 +152,19 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                         }
                     }
                     is ModifiedNote.Delete -> {
+                        val paragraphAdapter = adapter
+                        if(paragraphAdapter != null) {
+                            if (binding.transSheet.wordTranslation.isVisible) {
+                                // Note info is visible, because the note was deleted hide the word/note views
+                                setWordSheetViews(false)
+                            } else {
+                                // Otherwise just hide the regular sheet
+                                val behavior = BottomSheetBehavior.from(binding.transSheet.root)
+                                behavior.state = BottomSheetBehavior.STATE_HIDDEN
+                            }
+                            paragraphAdapter.unselectWord()
+                        }
+
                         adapter?.deleteNote(result.noteId)
                         sheet.addNoteBtn.setImageResource(R.drawable.baseline_note_add_24)
                     }
@@ -528,12 +541,11 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                         val paragraphAdapter = adapter
                         if (paragraphAdapter != null) {
                             addWordNoteBtn.isGone = !paragraphAdapter.isPageSaved
+                            val span = paragraphAdapter.getSelectedWordSpan()
+                            if(span != null) noteInfo = ParagraphAdapter.EditNote(word.word, word.definition, span, 0, 0)
                         }
 
                         addWordNoteBtn.setOnClickListener {
-                            paragraphAdapter ?: return@setOnClickListener
-                            val span = paragraphAdapter.getSelectedWordSpan() ?: return@setOnClickListener
-                            noteInfo = ParagraphAdapter.EditNote(word.word, word.definition, span, 0, 0)
                             addNoteDialogVisible.value = true
                         }
                         addWordNoteBtn.setImageResource(R.drawable.baseline_note_add_24)

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -146,7 +146,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                                 sheet.translatedText.text = note.text
                                 sheet.addNoteBtn.setImageResource(R.drawable.ic_edit_black_24dp)
                             }
-                            noteInfo = ParagraphAdapter.EditNote(note.originalText, note.text, span, Color.parseColor(note.color), note.id)
+                            noteInfo = ParagraphAdapter.EditNote(note.originalText, note.text, span, Color.parseColor(note.color), true, note.id)
                         } else {
                             highlightNote = null
                         }
@@ -225,6 +225,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                             addNoteVisible,
                             highlightNote?.noteText ?: noteInfo?.noteText ?: "",
                             highlightNote?.color ?: noteInfo?.color ?: 0,
+                            highlightNote?.noteSaved ?: noteInfo?.noteSaved ?: false,
                             onDismiss = {
                                 addNoteVisible = false
                                 highlightNote = null
@@ -494,7 +495,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                             addNoteBtn.setImageResource(R.drawable.baseline_note_add_24)
                             val span = paragraphAdapter.getSelectedWordSpan() ?: paragraphAdapter.getHighlightedTextSpan()
                             if(span != null) {
-                                noteInfo = ParagraphAdapter.EditNote(word.word, word.definition, span, 0, 0)
+                                noteInfo = ParagraphAdapter.EditNote(word.word, word.definition, span, 0, false, 0)
                             }
                         }
 
@@ -546,7 +547,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                         if (paragraphAdapter != null) {
                             addWordNoteBtn.isGone = !paragraphAdapter.isPageSaved
                             val span = paragraphAdapter.getSelectedWordSpan()
-                            if(span != null) noteInfo = ParagraphAdapter.EditNote(word.word, word.definition, span, 0, 0)
+                            if(span != null) noteInfo = ParagraphAdapter.EditNote(word.word, word.definition, span, 0, false, 0)
                         }
 
                         addWordNoteBtn.setOnClickListener {

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -353,7 +353,6 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                         val bottomSheetBehavior = BottomSheetBehavior.from(binding.transSheet.root)
                         if(bottomSheetBehavior.state == BottomSheetBehavior.STATE_HIDDEN){
                             paragraphAdapter.unselectSentence()
-                            setWordSheetViews(false)
                         } else {
                             viewModel.translateWordInSentence(it)
                             paragraphAdapter.updateWordInSentence()
@@ -466,10 +465,10 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                         adapter?.unselectWord()
                         setWordSheetViews(false)
                         binding.composeBar.isVisible = true
-                        updateBottomPadding(0)
+                        updateListBottomPadding(0)
                     } else if (newState == BottomSheetBehavior.STATE_EXPANDED) {
                         binding.composeBar.isVisible = false
-                        updateBottomPadding(root.height)
+                        updateListBottomPadding(root.height)
                     }
                 }
 
@@ -506,7 +505,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                         } else {
                             // Sheet layout modified but the sheet was already expanded, manually update padding
                             translatedText.post {
-                                updateBottomPadding(this.root.height)
+                                updateListBottomPadding(root.height)
                             }
                         }
                         true
@@ -538,6 +537,8 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                             viewModel.getLinksForWord(word.word, word.lang)
                         }
 
+                        setWordSheetViews(true)
+
                         val paragraphAdapter = adapter
                         if (paragraphAdapter != null) {
                             addWordNoteBtn.isGone = !paragraphAdapter.isPageSaved
@@ -549,7 +550,6 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                             addNoteDialogVisible.value = true
                         }
                         addWordNoteBtn.setImageResource(R.drawable.baseline_note_add_24)
-                        setWordSheetViews(true)
                         true
                     }
                     is LoadResult.Error -> {
@@ -610,6 +610,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
             if(isSheetVisible() && paragraphAdapter.isInsideSelectedSentence(note.span)){
                 // Update the word text and buttons
                 wordTranslation.text = note.noteText
+                setWordSheetViews(true)
                 moreInfoWordBtn.isVisible = isWord
                 moreInfoWordBtn.setOnClickListener {
                     getLinksForWord(note.text)
@@ -619,8 +620,6 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                 addWordNoteBtn.setOnClickListener {
                     addNoteDialogVisible.value = true
                 }
-
-                setWordSheetViews(true)
             } else {
                 // Otherwise show the regular sheet
                 translatedText.text = note.noteText
@@ -684,7 +683,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
             moreInfoWordBtn.isVisible = isVisible
             if(isVisible) {
                 wordTranslation.post {
-                    updateBottomPadding(root.height)
+                    updateListBottomPadding(root.height)
                 }
             }
             val padding = if (isVisible) 0 else resources.getDimensionPixelSize(R.dimen.default_dialog_padding)
@@ -692,7 +691,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
         }
     }
 
-    private fun updateBottomPadding(pixels: Int) {
+    private fun updateListBottomPadding(pixels: Int) {
         val extra = if(pixels == 0) appBarSize else requireContext().dpToPixel(16)
         binding.paragraphsList.updatePadding(bottom = pixels + extra)
     }

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -435,6 +435,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                 val adapter = ExternalLinksAdapter(it.links) { index ->
                     selectedPos = index
                     infoWebview.loadUrl(links[index].link)
+                    linksList.scrollToPosition(index)
                 }
                 adapter.setFlatButton(true)
                 adapter.setSelectedPos(selectedPos)
@@ -450,6 +451,8 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
     private fun setTranslateBottomPanel() {
         with(binding.transSheet) {
             translatedText.movementMethod = ScrollingMovementMethod()
+            wordTranslation.movementMethod = ScrollingMovementMethod()
+            wordTranslation.setHorizontallyScrolling(true)
             // This disables scrolling the bottom sheet when scrolling the translation text
             // This is done to allow the TextView to scroll up
             translatedText.setOnTouchListener { view, _ ->

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderScreen.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderScreen.kt
@@ -18,9 +18,12 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -30,7 +33,6 @@ import com.guillermonegrete.tts.ui.theme.BlueNoteHighlight
 import com.guillermonegrete.tts.ui.theme.GreenNoteHighlight
 import com.guillermonegrete.tts.ui.theme.RedNoteHighlight
 import com.guillermonegrete.tts.ui.theme.YellowNoteHighlight
-import kotlinx.coroutines.android.awaitFrame
 import okhttp3.internal.toHexString
 
 
@@ -230,6 +232,7 @@ fun AddNoteDialog(
 
     if (!isVisible) return
     val focusRequester = remember { FocusRequester() }
+    var textFieldLoaded by remember { mutableStateOf(false) }
 
     Dialog(onDismissRequest = { onDismiss() }) {
         Surface {
@@ -238,15 +241,21 @@ fun AddNoteDialog(
                 modifier = Modifier.padding(24.dp)
             ) {
 
-                var text by remember { mutableStateOf(noteText) }
+                var textFieldValue by remember { mutableStateOf(TextFieldValue(noteText, TextRange(noteText.length))) }
                 OutlinedTextField(
-                    value = text,
-                    onValueChange = { text = it },
+                    value = textFieldValue,
+                    onValueChange = { textFieldValue = it },
                     placeholder = { Text(stringResource(R.string.add_note_placeholder)) },
                     minLines = 4,
                     maxLines = 4,
                     modifier = Modifier
                         .focusRequester(focusRequester)
+                        .onGloballyPositioned {
+                            if (!textFieldLoaded) {
+                                focusRequester.requestFocus()
+                                textFieldLoaded = true // stop cyclic recompositions
+                            }
+                        }
                         .fillMaxWidth()
                         .testTag(NOTE_TEXT_TAG)
                 )
@@ -292,7 +301,7 @@ fun AddNoteDialog(
                     }
                     Spacer(modifier = Modifier.width(16.dp))
                     Button(onClick = {
-                        onSaveClicked(AddNoteResult(text, COLORS[colorSel].toHex()))
+                        onSaveClicked(AddNoteResult(textFieldValue.text, COLORS[colorSel].toHex()))
                     },
                         Modifier
                             .weight(1f)
@@ -303,14 +312,6 @@ fun AddNoteDialog(
                 }
             }
         }
-    }
-
-    // We only want to show the keyboard at start when the user is adding a new note.
-    if (noteText.isNotEmpty()) return
-    // Used to request focus which shows the keyboard
-    LaunchedEffect(Unit) {
-        awaitFrame()
-        focusRequester.requestFocus()
     }
 }
 

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderScreen.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderScreen.kt
@@ -225,6 +225,7 @@ fun AddNoteDialog(
     isVisible: Boolean,
     noteText: String,
     @ColorInt noteColor: Int,
+    noteSaved: Boolean = false,
     onDismiss: () -> Unit = {},
     onDelete: () -> Unit = {},
     onSaveClicked: (result: AddNoteResult) -> Unit = {},
@@ -293,13 +294,15 @@ fun AddNoteDialog(
                 }
 
                 Row {
-                    Button(onClick = { onDelete() },
-                        Modifier
-                            .weight(1f)
-                            .testTag(DELETE_BTN_TAG)) {
-                        Text(stringResource(id = R.string.delete))
+                    if(noteSaved) {
+                        Button(onClick = { onDelete() },
+                            Modifier
+                                .weight(1f)
+                                .testTag(DELETE_BTN_TAG)) {
+                            Text(stringResource(id = R.string.delete))
+                        }
+                        Spacer(modifier = Modifier.width(16.dp))
                     }
-                    Spacer(modifier = Modifier.width(16.dp))
                     Button(onClick = {
                         onSaveClicked(AddNoteResult(textFieldValue.text, COLORS[colorSel].toHex()))
                     },
@@ -408,7 +411,7 @@ fun DeletePageDialogPreview() {
 @Composable
 fun AddNoteDialogPreview() {
     AppTheme {
-        AddNoteDialog(true, "", 0)
+        AddNoteDialog(true, "", 0, true)
     }
 }
 

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
@@ -320,6 +320,8 @@ class WebReaderViewModel @Inject constructor(
         cacheWebLink?.language = langShort
     }
 
+    fun getLanguage() = cacheWebLink?.language
+
     private fun splitBySentence(paragraphs: List<CharSequence>): List<SplitParagraph> {
         val iterator = BreakIterator.getSentenceInstance()
 

--- a/app/src/main/res/layout/fragment_web_reader.xml
+++ b/app/src/main/res/layout/fragment_web_reader.xml
@@ -97,4 +97,9 @@
         android:text="@string/loading_page_error_msg"
         tools:visibility="visible"/>
 
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_root"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
 </RelativeLayout>

--- a/app/src/main/res/layout/translation_card.xml
+++ b/app/src/main/res/layout/translation_card.xml
@@ -101,7 +101,7 @@
             android:paddingVertical="8dp"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="@+id/translated_text"
+            app:layout_constraintEnd_toStartOf="@+id/add_word_note_btn"
             app:layout_constraintStart_toStartOf="@+id/translated_text"
             app:layout_constraintTop_toBottomOf="@id/notes_text"
             tools:text="Word translation"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -216,5 +216,6 @@
     <string name="add_note_for_word">Add note for word</string>
     <string name="more_information">More information for text</string>
     <string name="more_information_word">More information for word</string>
+    <string name="pick_language_web_reader">To see more information about this text, please pick a language using the bottom bar</string>
 
 </resources>


### PR DESCRIPTION
Closes #178.

The MoreInfo button not doing anything wasn't a bug but that was the behavior when no language is selected for the page. A message is now shown telling the user to pick a language.

Fixed other issues found:

- The keyboard wasn't shown at the start when showing the edit dialog.
- Fixed note within a sentence not getting deleted
- The link list now scrolls to the clicked item.
- The word translation text can be scrolled and doesn't overlap the icons anymore
- In the dialog, the delete button is not shown if the note is new.