### PR TITLE
Custom tabs is now the default mode to view external links.

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/DefaultWebBrowser.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/DefaultWebBrowser.kt
@@ -6,13 +6,13 @@ import android.net.Uri
 import com.guillermonegrete.tts.ui.webview.ChromeCustomTabsActivity
 
 enum class DefaultWebBrowser(val type: String) {
-    CHROME_CUSTOM_TABS("custom_tabs") {
+    CUSTOM_TABS("custom_tabs") {
         override fun intentForUrl(context: Context, url: String) =
             ChromeCustomTabsActivity.intent(context, url)
     },
     DEVICE_DEFAULT("default") {
         override fun intentForUrl(context: Context, url: String) =
-            Intent(Intent.ACTION_VIEW).apply { data = Uri.parse(url) }
+            Intent(Intent.ACTION_VIEW, Uri.parse(url))
     };
 
     abstract fun intentForUrl(context: Context, url: String): Intent
@@ -21,7 +21,7 @@ enum class DefaultWebBrowser(val type: String) {
         const val PREFERENCE_KEY = "default_browser_pref_key"
 
         fun get(type: String): DefaultWebBrowser {
-                return values().find { it.type == type } ?: DEVICE_DEFAULT
+                return values().find { it.type == type } ?: CUSTOM_TABS
         }
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/ExternalLinksFragment.java
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/ExternalLinksFragment.java
@@ -3,7 +3,6 @@ package com.guillermonegrete.tts.textprocessing;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,6 +16,7 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -96,7 +96,6 @@ public class ExternalLinksFragment extends Fragment {
     private DefaultWebBrowser getDefaultWebBrowser(){
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(requireContext());
         String preference = preferences.getString(DefaultWebBrowser.PREFERENCE_KEY, "");
-        if (preference == null) preference = "";
         return DefaultWebBrowser.Companion.get(preference);
     }
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -17,7 +17,7 @@
     </string-array>
 
     <string-array name="defaultBrowserArray">
-        <item>Chrome custom tabs</item>
+        <item>Custom tabs</item>
         <item>Device default</item>
     </string-array>
 

--- a/app/src/main/res/xml/preferences_main.xml
+++ b/app/src/main/res/xml/preferences_main.xml
@@ -50,7 +50,7 @@
             android:key="default_browser_pref_key"
             android:entries="@array/defaultBrowserArray"
             android:entryValues="@array/defaultBrowserValues"
-            android:defaultValue="default"/>
+            android:defaultValue="custom_tabs"/>
     </PreferenceCategory>
 
     <com.guillermonegrete.tts.customviews.ButtonsPreference


### PR DESCRIPTION
Closes #177.

Couldn't fix the issue from the app end, this issue is because of the browser. A workaround is to use Custom Tabs, which are now the default mode to open external links. Custom tabs is a more stable and lightweight way to view web links.