### PR TITLE
Uses octet-stream as the file type for APIs lower than 23.

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/importtext/ImportedFileType.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/ImportedFileType.kt
@@ -2,7 +2,11 @@ package com.guillermonegrete.tts.importtext
 
 enum class ImportedFileType(val mimeType: String) {
     TXT("text/plain"),
-    EPUB("application/epub+zip");
+    EPUB("application/epub+zip"),
+    /**
+     * In APIs < 23, EPUB files are treated as octet-streams.
+     */
+    OCTET_STREAM("application/octet-stream");
 
     companion object{
 

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/tabs/FilesFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/tabs/FilesFragment.kt
@@ -4,6 +4,7 @@ import android.animation.Animator
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -76,7 +77,7 @@ class FilesFragment: Fragment(R.layout.files_layout) {
                 }
 
                 when(fileType){
-                    ImportedFileType.EPUB -> visualizeEpub(uri, -1)
+                    ImportedFileType.EPUB, ImportedFileType.OCTET_STREAM -> visualizeEpub(uri, -1)
                     ImportedFileType.TXT -> readTextFile(uri)
                 }
             }
@@ -108,7 +109,8 @@ class FilesFragment: Fragment(R.layout.files_layout) {
 
             pickEpubFileBtn.apply {
                 setOnClickListener {
-                    fileType = ImportedFileType.EPUB
+                    // APIs lower than 23 don't have support for EPUB in the file picker so use octet-stream instead.
+                    fileType = if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1) ImportedFileType.EPUB else ImportedFileType.OCTET_STREAM
                     pickFile()
                 }
                 post { translationY = height.toFloat() }


### PR DESCRIPTION
Closes #188.