### PR TITLE
Feature/#189 clipboard older apis

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/main/SettingsFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/main/SettingsFragment.kt
@@ -1,6 +1,7 @@
 package com.guillermonegrete.tts.main
 
 
+import android.os.Build
 import android.os.Bundle
 import android.view.*
 import androidx.appcompat.app.AppCompatActivity
@@ -8,6 +9,7 @@ import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
 import androidx.lifecycle.Lifecycle
 import androidx.preference.ListPreference
+import androidx.preference.Preference
 
 import com.guillermonegrete.tts.R
 
@@ -42,6 +44,11 @@ class SettingsFragment : PreferenceFragmentCompat(), MenuProvider {
         setPreferencesFromResource(R.xml.preferences_main, rootKey)
 
         val themePreference: ListPreference? = findPreference(PREF_THEME)
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            val clipboardPreference: Preference? = findPreference(PREF_CLIPBOARD_SWITCH)
+            clipboardPreference?.isVisible = true
+        }
 
         themePreference?.setOnPreferenceChangeListener { _, newValue ->
             val themeOption = newValue as String

--- a/app/src/main/res/layout/main_tts_layout.xml
+++ b/app/src/main/res/layout/main_tts_layout.xml
@@ -67,9 +67,21 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="24dp"
         android:text="@string/startBubble_button_name"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/clipboard_btn"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/browse_btn" />
+
+    <Button
+        android:id="@+id/clipboard_btn"
+        style="@style/Widget.MaterialComponents.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="48dp"
+        android:text="@string/clipboard_btn_caption"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/startBubble_btn"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/startBubble_btn"
+        app:layout_constraintTop_toTopOf="@+id/startBubble_btn" />
 
     <FrameLayout
         android:id="@+id/play_icons_container"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,12 @@
     <!--Text to speech fragment-->
     <string name="overlay_notification_permission_rationale">Notifications make the experience better by allowing you to easily show and close the floating icon</string>
 
+    <!--Screen Text Service-->
+    <string name="clipboard_notification_title">Clipboard translation is activated</string>
+    <string name="notification_title">Speakable overlay</string>
+    <string name="notification_text">Tap to start text recognition</string>
+    <string name="notification_text_short">Tap to start</string>
+
     <!--Saved words fragment-->
     <string name="no_words_saved">No words found</string>
 

--- a/app/src/main/res/xml-v25/shortcuts.xml
+++ b/app/src/main/res/xml-v25/shortcuts.xml
@@ -1,16 +1,4 @@
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
-    <shortcut
-        android:shortcutId="clipboard_mode"
-        android:enabled="true"
-        android:icon="@drawable/ic_content_copy_black_24dp"
-        android:shortcutShortLabel="@string/clipboard_shortcut_short_label"
-        android:shortcutLongLabel="@string/clipboard_shortcut_long_label"
-        android:shortcutDisabledMessage="@string/clipboard_shortcut_disabled_message">
-        <intent
-            android:action="android.intent.action.VIEW"
-            android:targetClass="com.guillermonegrete.tts.main.StartOverlayModeActivity"
-            android:targetPackage="com.guillermonegrete.tts"/>
-    </shortcut>
 
     <shortcut
         android:shortcutId="overlay_mode"

--- a/app/src/main/res/xml/preferences_main.xml
+++ b/app/src/main/res/xml/preferences_main.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
+
     <SwitchPreferenceCompat
         android:key="auto_tts_switch"
         android:title="TTS automatically"
-        android:summary="Enable automatically text to speech"
-        />
+        android:summary="Enable automatically text to speech" />
+
     <SwitchPreferenceCompat
         android:key="clipboard_show_dialog"
-        android:title="Show when text copied"
+        android:title="Show dialog on copy"
         android:summary="Show dialog when text is copied to clipboard"
-        />
+        app:isPreferenceVisible="false"/>
 
     <PreferenceCategory
         android:title="Text recognizer">


### PR DESCRIPTION
Closes #189.

Add clipboard support for API lower than 24. For 24+ the clipboard shortcut and preference were removed. Also, the text of the notification was changed for the higher APIs.