### PR TITLE
Bugfix/#197 highlighted text

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/webreader/ParagraphAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/ParagraphAdapter.kt
@@ -37,6 +37,7 @@ class ParagraphAdapter(
     val viewModel: WebReaderViewModel,
     val onSentenceSelected: () -> Unit,
     val onTextHighlighted: () -> Unit = {},
+    val onTranslateHighlightedText: (String) -> Unit = {},
 ): RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     var expandedItemPos = -1
@@ -347,6 +348,7 @@ class ParagraphAdapter(
 
                 menu.clear()
                 menu.add(Menu.NONE, android.R.id.copy, Menu.NONE, android.R.string.copy)
+                menu.add(Menu.NONE, TRANSLATE_MENU_ITEM_ID, Menu.NONE, R.string.translate_description)
 
                 val selStart = binding.paragraph.selectionStart
                 val selEnd = binding.paragraph.selectionEnd
@@ -379,6 +381,12 @@ class ParagraphAdapter(
                         mode?.finish()
                         true
                     }
+                    TRANSLATE_MENU_ITEM_ID -> {
+                        val text = getHighlightedText() ?: return false
+                        onTranslateHighlightedText(text.toString())
+                        mode?.finish()
+                        true
+                    }
                     else -> false
                 }
             }
@@ -386,7 +394,8 @@ class ParagraphAdapter(
             override fun onDestroyActionMode(mode: ActionMode?) {
                 highlightedTextView = null
                 highlightedTextPos = -1
-                isOverlappingNotes = false
+                // Only reset this flag if no text was selected using the mode (if text was selected it may overlap notes)
+                if (selectedWordPos == -1) isOverlappingNotes = false
             }
 
         }
@@ -444,6 +453,7 @@ class ParagraphAdapter(
             previousItem.selectedWord = null
             notifyItemChanged(selectedWordPos, -1)
             selectedWordPos = -1
+            isOverlappingNotes = false
         }
 
         // unselect word that is within a sentence
@@ -728,7 +738,20 @@ class ParagraphAdapter(
         return Span(start - paragraphItem.firstCharIndex, end - paragraphItem.firstCharIndex)
     }
 
+    fun selectHighlightedText() {
+        val pos = highlightedTextPos
+        val textView = highlightedTextView ?: return
+        val item = items[pos]
+        val span = Span(textView.selectionStart, textView.selectionEnd)
+        item.selectedWord = span
+        selectedWordPos = pos
+        textView.clearFocus()
+        notifyItemChanged(pos, PAYLOAD_WORD)
+    }
+
     companion object {
+        private const val TRANSLATE_MENU_ITEM_ID = 3
+
         private const val SWIPE_THRESHOLD = 0.8
         private const val SWIPE_VELOCITY_THRESHOLD = 0.8
 

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -65,17 +65,8 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
 
     /**
      * Contains information used to update/create/delete a note.
-     *
-     * This information is the one displayed in the bottom sheet
      */
     private var noteInfo: ParagraphAdapter.EditNote? = null
-
-    /**
-     * The data for creating a note using the text highlight method.
-     *
-     * This data is independent from the one displayed in the bottom sheet
-     */
-    private var highlightNote: ParagraphAdapter.EditNote? = null
 
     private var appBarSize = 0
 
@@ -137,7 +128,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                         val paragraphAdapter = adapter ?: return@observe
                         paragraphAdapter.updateNote(span, note.id, dialogResult)
 
-                        if(span != highlightNote?.span) {
+                        if(isSheetVisible()) {
                             if (paragraphAdapter.selectedSentence.wordSelected ||
                                 paragraphAdapter.isInsideSelectedSentence(span)) { // if not word selected but still inside the sentence then it must be a note
                                 sheet.wordTranslation.text = note.text
@@ -148,7 +139,8 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                             }
                             noteInfo = ParagraphAdapter.EditNote(note.originalText, note.text, span, Color.parseColor(note.color), true, note.id)
                         } else {
-                            highlightNote = null
+                            // If sheet not visible note was added using the selected text menu, no UI to update
+                            noteInfo = null
                         }
                     }
                     is ModifiedNote.Delete -> {
@@ -223,21 +215,18 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
 
                         AddNoteDialog(
                             addNoteVisible,
-                            highlightNote?.noteText ?: noteInfo?.noteText ?: "",
-                            highlightNote?.color ?: noteInfo?.color ?: 0,
-                            highlightNote?.noteSaved ?: noteInfo?.noteSaved ?: false,
-                            onDismiss = {
-                                addNoteVisible = false
-                                highlightNote = null
-                            },
+                            noteInfo?.noteText ?: "",
+                            noteInfo?.color ?: 0,
+                            noteInfo?.noteSaved ?: false,
+                            onDismiss = { addNoteVisible = false },
                             onDelete = {
-                                if (highlightNote != null) highlightNote = null
                                 val noteItem = noteInfo ?: return@AddNoteDialog
                                 viewModel.deleteNote(noteItem.id)
+                                noteInfo = null
                                 addNoteVisible = false
                             },
                             onSaveClicked = { newNote ->
-                                val noteItem = highlightNote ?: noteInfo ?: return@AddNoteDialog
+                                val noteItem = noteInfo ?: return@AddNoteDialog
                                 viewModel.saveNote(noteItem.text, newNote.text, noteItem.span, noteItem.id, newNote.colorHex)
                                 addNoteVisible = false
                             },
@@ -368,12 +357,11 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
 
                 launch {
                     paragraphAdapter.addNoteClicked.collect { note ->
+                        noteInfo = note
                         if (note.id == 0L) {
                             // zero means new note, show dialog to add note
-                            highlightNote = note
                             addNoteDialogVisible.value = true
                         } else {
-                            noteInfo = note
                             showSheetWithNote(paragraphAdapter, note)
                         }
                     }
@@ -398,7 +386,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
         }, viewLifecycleOwner, Lifecycle.State.RESUMED)
     }
 
-    @SuppressLint("ClickableViewAccessibility")
+    @SuppressLint("ClickableViewAccessibility", "SetJavaScriptEnabled")
     private fun setBottomPanel(){
         with(binding) {
             val bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet)
@@ -429,7 +417,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
             linksList.addItemDecoration(decor)
 
             var selectedPos = 0
-            viewModel.clickedWord.observe(viewLifecycleOwner) {
+            viewModel.linksForWord.observe(viewLifecycleOwner) {
                 val links = it.links
                 links.forEach { link -> link.link = link.link.replace("{q}", it.word) }
 

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -329,12 +329,17 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
             val newAdapter = ParagraphAdapter(paragraphItems, page.isLocalPage, viewModel,
                 onSentenceSelected = { hideBottomSheets() },
                 onTextHighlighted = {
-                val highlightSpan = adapter?.getHighlightedTextSpan()
-                val sheetSpan = noteInfo?.span
-                if(highlightSpan != sheetSpan) {
-                    hideBottomSheets()
+                    val highlightSpan = adapter?.getHighlightedTextSpan()
+                    val sheetSpan = noteInfo?.span
+                    if(highlightSpan != sheetSpan) {
+                        hideBottomSheets()
+                    }
+                },
+                onTranslateHighlightedText = {
+                    viewModel.translateText(it)
+                    adapter?.selectHighlightedText()
                 }
-            })
+            )
             adapter = newAdapter
             paragraphsList.adapter = adapter
 
@@ -603,6 +608,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
         val text = adapter.getHighlightedText()
         if (text != null) {
             viewModel.translateText(text.toString())
+            adapter.selectHighlightedText()
         }
     }
 

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
@@ -61,8 +61,8 @@ class WebReaderViewModel @Inject constructor(
     private val _wordInfo = MutableLiveData<LoadResult<WordResult>>()
     val wordInfo: LiveData<LoadResult<WordResult>> = _wordInfo
 
-    private val _clickedWord = MutableLiveData<WordAndLinks>()
-    val clickedWord: LiveData<WordAndLinks> = _clickedWord
+    private val _linksForWord = MutableLiveData<WordAndLinks>()
+    val linksForWord: LiveData<WordAndLinks> = _linksForWord
 
     private val _updatedNote = MutableLiveData<ModifiedNote>()
     val updatedNote: LiveData<ModifiedNote> = _updatedNote
@@ -160,7 +160,7 @@ class WebReaderViewModel @Inject constructor(
      */
     private fun readContentFile(uuid: UUID): String {
         val rootFolder = File(folderPath, uuid.toString())
-        val file = File(rootFolder, page_filename)
+        val file = File(rootFolder, PAGE_FILENAME)
         val doc = Jsoup.parse(file, null)
         return doc.outerHtml()
     }
@@ -307,7 +307,7 @@ class WebReaderViewModel @Inject constructor(
     fun getLinksForWord(word: String, lang: String) {
         viewModelScope.launch {
             val links = withContext(ioDispatcher) { getExternalLinksInteractor(lang) }
-            _clickedWord.value = WordAndLinks(word, links)
+            _linksForWord.value = WordAndLinks(word, links)
         }
     }
 
@@ -381,7 +381,7 @@ class WebReaderViewModel @Inject constructor(
 
         if (!makeDir(folder)) return
 
-        val contentFile = File(folder, page_filename)
+        val contentFile = File(folder, PAGE_FILENAME)
         writeToFile(contentFile, content)
 
         link.uuid = uuid
@@ -440,7 +440,7 @@ class WebReaderViewModel @Inject constructor(
     data class Page(val title: String, val content: String)
 
     companion object {
-        private const val page_filename = "content.xml"
+        private const val PAGE_FILENAME = "content.xml"
     }
 }
 

--- a/app/src/test/java/com/guillermonegrete/tts/webreader/WebReaderViewModelTest.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/webreader/WebReaderViewModelTest.kt
@@ -373,7 +373,7 @@ class WebReaderViewModelTest {
         viewModel.onWordClicked("hola", 0)
         advanceUntilIdle()
 
-        assertEquals(WordAndLinks("hola", links), viewModel.clickedWord.getOrAwaitValue())
+        assertEquals(WordAndLinks("hola", links), viewModel.linksForWord.getOrAwaitValue())
     }
 
 


### PR DESCRIPTION
Closes #197.

The menu disappears when the translate button is clicked, the selected text is now highlighted like a tapped word. 
Also added an option to translate the selection in the context menu.