### PR TITLE
Hotfix/text dialog

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/data/source/remote/WiktionarySource.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/remote/WiktionarySource.java
@@ -52,11 +52,13 @@ public class WiktionarySource implements DictionaryDataSource {
 
                 if (response.isSuccessful() && response.body() != null) {
 
-                    String htmlText = response.body().getParse().getText();
-                    if(htmlText != null) {
+                    var parseAction = response.body().getParse();
+                    if(parseAction != null) {
+                        String htmlText = parseAction.getText();
                         var items = WiktionaryParser.parse(htmlText);
                         callback.onDefinitionLoaded(items);
                     } else {
+                        // If the word doesn't exist then parse is null
                         callback.onDataNotAvailable();
                     }
                 } else {
@@ -77,9 +79,11 @@ public class WiktionarySource implements DictionaryDataSource {
         public static List<WikiItem> parse(String htmlText) {
             Document doc = Jsoup.parse(htmlText);
             // Remove table of contents at the start
-            doc.getElementById("toc").remove();
+            var toc = doc.getElementById("toc");
+            if (toc != null) toc.remove();
             // Remove all the edit buttons/text
-            doc.getElementsByClass("mw-editsection").remove();
+            var editSections = doc.getElementsByClass("mw-editsection");
+            if (editSections != null) editSections.remove();
             CharSequence info = formatHtml(doc.outerHtml());
             return List.of(new WiktionaryItem(info, ""));
         }

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextActivity.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextActivity.kt
@@ -48,7 +48,7 @@ import com.guillermonegrete.tts.importtext.visualize.model.BookChapter
 import com.guillermonegrete.tts.importtext.visualize.model.SplitPageSpan
 import com.guillermonegrete.tts.textprocessing.TextInfoDialog
 import com.guillermonegrete.tts.ui.BrightnessTheme
-import com.guillermonegrete.tts.ui.theme.AppTheme
+import com.guillermonegrete.tts.ui.theme.VisualizerTheme
 import com.guillermonegrete.tts.utils.getScreenSizes
 import com.guillermonegrete.tts.webreader.AddNoteDialog
 import com.guillermonegrete.tts.webreader.model.ModifiedNote
@@ -151,7 +151,7 @@ class VisualizeTextActivity: AppCompatActivity() {
     private fun setupCompose() {
         binding.composeRoot.apply {
             setContent {
-                AppTheme {
+                VisualizerTheme(theme = brightnessTheme) {
                     Sheet()
                     
                     Dialogs()

--- a/app/src/main/java/com/guillermonegrete/tts/ui/BrightnessTheme.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/ui/BrightnessTheme.kt
@@ -9,7 +9,7 @@ enum class BrightnessTheme(val value: String) {
         const val PREFERENCE_KEY = "brightness_pref_key"
 
         fun get(value: String): BrightnessTheme {
-            return values().find { it.value == value } ?: WHITE
+            return entries.find { it.value == value } ?: WHITE
         }
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/ui/theme/Theme.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/ui/theme/Theme.kt
@@ -5,6 +5,8 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.guillermonegrete.tts.ui.BrightnessTheme
 
 private val DarkColorPalette = darkColors(
     primary = GreenLight,
@@ -29,6 +31,16 @@ private val LightColorPalette = lightColors(
     */
 )
 
+private val BeigeColorPalette = lightColors(
+    primary = GreenLight,
+    primaryVariant = GreenDark,
+    secondary = BlueLight,
+    secondaryVariant = BlueDark,
+
+    background = Color(0Xffffedbf),
+    surface = Color(0Xffffedbf),
+)
+
 @Composable
 fun AppTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
@@ -38,6 +50,23 @@ fun AppTheme(
         DarkColorPalette
     } else {
         LightColorPalette
+    }
+
+    MaterialTheme(
+        colors = colors,
+        content = content
+    )
+}
+
+@Composable
+fun VisualizerTheme(
+    theme: BrightnessTheme,
+    content: @Composable () -> Unit
+) {
+    val colors = when(theme) {
+        BrightnessTheme.WHITE -> LightColorPalette
+        BrightnessTheme.BEIGE -> BeigeColorPalette
+        BrightnessTheme.BLACK -> DarkColorPalette
     }
 
     MaterialTheme(


### PR DESCRIPTION
Fixed crashes in the text dialog. When the word didn't have a Wiktionary page and when the page didn't have either a table of contents or an edit button.
Also, fixed compose widgets not having the beige theme.