### PR TITLE
Hotfix/update saved word

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -164,7 +164,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // Coroutines
-    def coroutines_version = "1.6.4"
+    def coroutines_version = "1.8.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 

--- a/app/src/main/java/com/guillermonegrete/tts/common/models/UI.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/common/models/UI.kt
@@ -9,7 +9,9 @@ data class WordUI(
     val definition: String,
     val notes: String? = null
 ) {
-    fun toWord() = Words(word, lang, definition)
+    fun toWord() = Words(word, lang, definition).also { dbWord ->
+        dbWord.notes = notes
+    }
 }
 
 fun Words.toUI() = WordUI(word, lang, definition, notes)

--- a/app/src/main/java/com/guillermonegrete/tts/data/Translation.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/data/Translation.kt
@@ -1,5 +1,7 @@
 package com.guillermonegrete.tts.data
 
+import com.guillermonegrete.tts.db.Words
+
 data class Translation(
     val sentences: List<Segment>,
     /**
@@ -14,6 +16,8 @@ data class Translation(
 }
 
 data class Segment(val trans: String, val orig: String)
+
+fun Translation.toWord() = Words(originalText, src, translatedText)
 
 /**
  * Used as the key for the cache of remote translations.

--- a/app/src/main/java/com/guillermonegrete/tts/data/Translation.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/data/Translation.kt
@@ -14,3 +14,8 @@ data class Translation(
 }
 
 data class Segment(val trans: String, val orig: String)
+
+/**
+ * Used as the key for the cache of remote translations.
+ */
+data class TranslationKey(val word: String, val languageFrom: String, val languageTo: String)

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/WordDataSource.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/WordDataSource.java
@@ -22,7 +22,7 @@ public interface WordDataSource {
 
     List<String> getLanguagesISO();
 
-    int insertWord(Words word);
+    int insertWord(@NonNull Words word);
 
     void insertWords(Words... words);
 

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/WordDataSource.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/WordDataSource.java
@@ -22,6 +22,8 @@ public interface WordDataSource {
 
     List<String> getLanguagesISO();
 
+    int insertWord(Words word);
+
     void insertWords(Words... words);
 
     void deleteWords(Words... words);

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/WordRepository.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/WordRepository.java
@@ -6,6 +6,7 @@ import androidx.lifecycle.LiveData;
 import com.guillermonegrete.tts.data.Result;
 import com.guillermonegrete.tts.data.Translation;
 import com.guillermonegrete.tts.data.TranslationKey;
+import com.guillermonegrete.tts.data.TranslationKt;
 import com.guillermonegrete.tts.data.source.local.WordLocalDataSource;
 import com.guillermonegrete.tts.db.Words;
 import com.guillermonegrete.tts.di.ApplicationModule;
@@ -27,7 +28,7 @@ public class WordRepository implements WordRepositorySource {
 
     private final TranslationSource translationSource;
 
-    private final ConcurrentMap<TranslationKey, Words> cachedWords;
+    private final ConcurrentMap<TranslationKey, Translation> translationCache;
 
 
     @Inject
@@ -36,7 +37,7 @@ public class WordRepository implements WordRepositorySource {
         mWordLocalDataSource = checkNotNull(wordLocalDataSource);
         this.translationSource = translationSource;
 
-        cachedWords = new ConcurrentHashMap<>();
+        translationCache = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -94,8 +95,15 @@ public class WordRepository implements WordRepositorySource {
 
     @Override
     public Result<Translation> getTranslation(@NonNull String text, @NonNull String languageFrom, @NonNull String languageTo) {
+        var key = new TranslationKey(text, languageFrom, languageTo);
+        var cacheTranslation = translationCache.get(key);
+        if (cacheTranslation != null) {
+            return new Result.Success<>(cacheTranslation);
+        }
+
         try{
             Translation wordTranslation = translationSource.getTranslation(text, languageFrom, languageTo);
+            translationCache.put(key, wordTranslation);
             return new Result.Success<>(wordTranslation);
         }catch (Exception e){
             return new Result.Error<>(e);
@@ -127,17 +135,17 @@ public class WordRepository implements WordRepositorySource {
     private void getRemoteWord(String wordText, String languageFrom, String languageTo, final GetWordRepositoryCallback callback) {
 
         var key = new TranslationKey(wordText, languageFrom, languageTo);
-        var cacheWord = cachedWords.get(key);
-        if (cacheWord != null) {
-            callback.onRemoteWordLoaded(cacheWord);
+        var cacheTranslation = translationCache.get(key);
+        if (cacheTranslation != null) {
+            var word = TranslationKt.toWord(cacheTranslation);
+            callback.onRemoteWordLoaded(word);
             return;
         }
 
         try{
             var translation = translationSource.getTranslation(wordText, languageFrom, languageTo);
-            var word = new Words(wordText, translation.getSrc(), translation.getTranslatedText());
-            callback.onRemoteWordLoaded(word);
-            cachedWords.put(key, word);
+            callback.onRemoteWordLoaded(TranslationKt.toWord(translation));
+            translationCache.put(key, translation);
         }catch (Exception e){
             callback.onDataNotAvailable(new Words(wordText, "un", "un"));
         }

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/WordRepository.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/WordRepository.java
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData;
 
 import com.guillermonegrete.tts.data.Result;
 import com.guillermonegrete.tts.data.Translation;
+import com.guillermonegrete.tts.data.TranslationKey;
 import com.guillermonegrete.tts.data.source.local.WordLocalDataSource;
 import com.guillermonegrete.tts.db.Words;
 import com.guillermonegrete.tts.di.ApplicationModule;
@@ -26,7 +27,7 @@ public class WordRepository implements WordRepositorySource {
 
     private final TranslationSource translationSource;
 
-    private final ConcurrentMap<String, Words> cachedWords;
+    private final ConcurrentMap<TranslationKey, Words> cachedWords;
 
 
     @Inject
@@ -125,17 +126,18 @@ public class WordRepository implements WordRepositorySource {
 
     private void getRemoteWord(String wordText, String languageFrom, String languageTo, final GetWordRepositoryCallback callback) {
 
-        Words cacheWord = cachedWords.get(wordText);
-        if(cachedWords.get(wordText) != null){
+        var key = new TranslationKey(wordText, languageFrom, languageTo);
+        var cacheWord = cachedWords.get(key);
+        if (cacheWord != null) {
             callback.onRemoteWordLoaded(cacheWord);
             return;
         }
 
         try{
-            Translation translation = translationSource.getTranslation(wordText, languageFrom, languageTo);
-            Words word = new Words(wordText, translation.getSrc(), translation.getTranslatedText());
+            var translation = translationSource.getTranslation(wordText, languageFrom, languageTo);
+            var word = new Words(wordText, translation.getSrc(), translation.getTranslatedText());
             callback.onRemoteWordLoaded(word);
-            cachedWords.put(wordText, word);
+            cachedWords.put(key, word);
         }catch (Exception e){
             callback.onDataNotAvailable(new Words(wordText, "un", "un"));
         }

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/local/WordLocalDataSource.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/local/WordLocalDataSource.java
@@ -33,6 +33,11 @@ public class WordLocalDataSource implements WordDataSource {
     }
 
     @Override
+    public int insertWord(Words word) {
+        return (int) mWordDAO.insert(word);
+    }
+
+    @Override
     public void getWordLanguageInfo(String wordText, String languageFrom, String languageTo, GetWordCallback callback) {
         Words retrieved_word = mWordDAO.findWord(wordText);
         if(retrieved_word == null){

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/local/WordLocalDataSource.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/local/WordLocalDataSource.java
@@ -33,7 +33,7 @@ public class WordLocalDataSource implements WordDataSource {
     }
 
     @Override
-    public int insertWord(Words word) {
+    public int insertWord(@NonNull Words word) {
         return (int) mWordDAO.insert(word);
     }
 

--- a/app/src/main/java/com/guillermonegrete/tts/savedwords/SaveWordDialogViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/savedwords/SaveWordDialogViewModel.kt
@@ -54,7 +54,7 @@ class SaveWordDialogViewModel @Inject constructor(
 
 sealed class ResultType {
     data class Insert(val word: Words): ResultType()
-    object Update : ResultType()
+    data object Update : ResultType()
 }
 
 /**
@@ -89,7 +89,7 @@ fun setContent(
                 languages = languages,
                 languagesISO = languagesISO,
                 isSaved = isSaved,
-                onSave = { onSave(it) },
+                onSave = { onSave(it.toWord()) },
                 onDelete = { deleteDialogShown = true },
                 onDismiss = { editDialogShown = false }
             )

--- a/app/src/main/java/com/guillermonegrete/tts/savedwords/SaveWordDialogViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/savedwords/SaveWordDialogViewModel.kt
@@ -39,7 +39,8 @@ class SaveWordDialogViewModel @Inject constructor(
             return
 
         viewModelScope.launch {
-            withContext(ioDispatcher) { wordSource.insertWords(word) }
+            val id = withContext(ioDispatcher) { wordSource.insertWord(word) }
+            word.id = id
             _update.value = ResultType.Insert(word)
         }
     }
@@ -47,14 +48,14 @@ class SaveWordDialogViewModel @Inject constructor(
     fun update(newWord: Words){
         viewModelScope.launch {
             val rowsUpdated = withContext(ioDispatcher) { wordSource.update(newWord) }
-            if(rowsUpdated > 0) _update.value = ResultType.Update
+            if(rowsUpdated > 0) _update.value = ResultType.Update(newWord)
         }
     }
 }
 
 sealed class ResultType {
     data class Insert(val word: Words): ResultType()
-    data object Update : ResultType()
+    data class Update(val word: Words): ResultType()
 }
 
 /**

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
@@ -278,6 +278,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
                     if (_bindingWord != null) {
                         setSavedWordToolbar()
                     }
+                    updateDatabaseWord(result.word.id)
                     wordState.value = wordState.value.copy(word = result.word.toUI(), dbId = result.word.id)
                 }
                 is ResultType.Update -> {
@@ -476,6 +477,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
         val oldWord = wordState.value.word ?: return
         val word = WordUI(oldWord.word, oldWord.lang, oldWord.definition) // Deleted word has same values but no id and notes
         wordState.value = wordState.value.copy(word = word, dbId = NOT_SAVED_ID)
+        updateDatabaseWord(NOT_SAVED_ID)
         deleteDialogShown.value = false
         editDialogShown.value = false
     }
@@ -814,6 +816,12 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
         }
     }
 
+    private fun updateDatabaseWord(id: Int) {
+        val fragment = childFragmentManager.fragments.find { it is TranslationFragment}
+        if (fragment != null && fragment is TranslationFragment) {
+            fragment.setWordId(id)
+        }
+    }
 
     private inner class MyPageAdapter(fragment: Fragment) :
         FragmentStateAdapter(fragment) {

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
@@ -384,14 +384,11 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
         createSmallViewPager()
 
         setSavedWordToolbar()
-        languagePreferenceIndex = -1 // Indicates spinner not visible
-
     }
 
     override fun setDictWithSaveWordLayout(word: Words, items: List<WikiItem>) {
         setWiktionaryLayout(word, items)
         setSavedWordToolbar()
-        languagePreferenceIndex = -1 // Indicates spinner not visible
     }
 
     override fun showTranslationError(error: String) {
@@ -542,7 +539,8 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
 
             val fragment = pagerAdapter?.fragments?.get(fragIndex)
             val word = Words(inputText ?: "", translation.src, translation.translatedText)
-            if (fragment is TranslationFragment) fragment.updateTranslation(word)
+            if (fragment is TranslationFragment) fragment.updateTranslation(word, languagePreferenceIndex)
+            wordState.value = wordState.value.copy(word = word.toUI())
         } else {
             if(selectedSpans.value != null) selectedSpans.value = null
             translatedText.value = translation.translatedText
@@ -744,6 +742,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
     private val translationFragListener = object : TranslationFragment.Listener {
         override fun onItemSelected(position: Int) {
             languageToISO = languagesISO[position]
+            languagePreferenceIndex = position
             val editor = preferences.edit()
             editor.putInt(LANGUAGE_PREFERENCE, position)
             editor.apply()
@@ -765,6 +764,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
                         "auto"
                     else
                         languagesISO[position - 1]
+                    languageFromIndex = position
                     editor.putString(SettingsFragment.PREF_LANGUAGE_FROM, languageFrom)
                     editor.apply()
                     presenter.onLanguageSpinnerChange(languageFrom, languageToISO)
@@ -789,6 +789,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
     }
 
     private fun updateLanguageTo(position: Int) {
+        languagePreferenceIndex = position
         languageToISO = languagesISO[position]
         val editor = preferences.edit()
         editor.putInt(LANGUAGE_PREFERENCE, position)

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
@@ -277,11 +277,13 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
                     editDialogShown.value = false
                     if (_bindingWord != null) {
                         setSavedWordToolbar()
-                    } else {
-                        wordState.value = wordState.value.copy(word = result.word.toUI(), dbId = result.word.id)
                     }
+                    wordState.value = wordState.value.copy(word = result.word.toUI(), dbId = result.word.id)
                 }
-                ResultType.Update -> editDialogShown.value = false
+                is ResultType.Update -> {
+                    wordState.value = wordState.value.copy(word = result.word.toUI())
+                    editDialogShown.value = false
+                }
             }
         }
     }
@@ -470,12 +472,10 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
     override fun showWordDeleted() {
         if (_bindingWord != null) {
             bindingWord.saveIcon.setImageResource(R.drawable.ic_bookmark_border_black_24dp)
-            wordState.value = wordState.value.copy(dbId = NOT_SAVED_ID)
-        } else {
-            val oldWord = wordState.value.word ?: return
-            val word = WordUI(oldWord.word, oldWord.lang, oldWord.definition) // Deleted word has same values but no id and notes
-            wordState.value = wordState.value.copy(word = word, dbId = NOT_SAVED_ID)
         }
+        val oldWord = wordState.value.word ?: return
+        val word = WordUI(oldWord.word, oldWord.lang, oldWord.definition) // Deleted word has same values but no id and notes
+        wordState.value = wordState.value.copy(word = word, dbId = NOT_SAVED_ID)
         deleteDialogShown.value = false
         editDialogShown.value = false
     }

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.distinctUntilChanged
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayoutMediator
@@ -65,7 +64,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
 
     private var inputText: String? = null
 
-    private lateinit var mFoundWords: Words
+    private var mFoundWords: Words? = null
     private var dbWord: Words? = null
 
     @Inject
@@ -249,10 +248,6 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
             }
         }
 
-        presenter.wordStream(inputText, languageFrom).distinctUntilChanged().observe(this) {
-            dbWord = it
-        }
-
         presenterImp.wordInfo().observe(this) {result ->
             when(result) {
                 is WordResult.Local -> wordState.value = WordState(result.word.toUI(), result.word.id, selectedWordSpan)
@@ -276,13 +271,15 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
                 is ResultType.Insert -> {
                     editDialogShown.value = false
                     if (_bindingWord != null) {
-                        setSavedWordToolbar()
+                        setSavedWordToolbar(result.word)
                     }
                     updateDatabaseWord(result.word.id)
                     wordState.value = wordState.value.copy(word = result.word.toUI(), dbId = result.word.id)
+                    dbWord = result.word
                 }
                 is ResultType.Update -> {
                     wordState.value = wordState.value.copy(word = result.word.toUI())
+                    dbWord = result.word
                     editDialogShown.value = false
                 }
             }
@@ -364,12 +361,16 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
         }
     }
 
+    private fun setDictRemoteWordLayout(word: Words, items: List<WikiItem>) {
+        mFoundWords = word
+        setWiktionaryLayout(word, items)
+    }
+
     private fun setWiktionaryLayout(word: Words, items: List<WikiItem>) {
         val isLargeWindow = preferences.getBoolean(SettingsFragment.PREF_WINDOW_SIZE, ButtonsPreference.DEFAULT_VALUE)
         if (isLargeWindow) setCenterDialog() else setBottomDialog()
         dictionaryAdapter = WiktionaryAdapter(items)
 
-        mFoundWords = word
         setWordLayout(word)
 
         if (isLargeWindow) createViewPager() else createSmallViewPager()
@@ -378,17 +379,16 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
 
     override fun setSavedWordLayout(word: Words) {
         setBottomDialog()
-        mFoundWords = word
-
-//        setWordLayout(word)
+        dbWord = word
         createSmallViewPager()
 
-        setSavedWordToolbar()
+        setSavedWordToolbar(word)
     }
 
     override fun setDictWithSaveWordLayout(word: Words, items: List<WikiItem>) {
+        dbWord = word
         setWiktionaryLayout(word, items)
-        setSavedWordToolbar()
+        setSavedWordToolbar(word)
     }
 
     override fun showTranslationError(error: String) {
@@ -421,9 +421,12 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
         if (dictionaryAdapter != null) pagerAdapter.addFragment(
             DefinitionFragment.newInstance(dictionaryAdapter)
         )
-        val translationFragment = TranslationFragment.newInstance(mFoundWords, languagePreferenceIndex)
-        translationFragment.setListener(translationFragListener)
-        pagerAdapter.addFragment(translationFragment)
+        val word = dbWord ?: mFoundWords
+        if (word != null) {
+            val translationFragment = TranslationFragment.newInstance(word, languagePreferenceIndex)
+            translationFragment.setListener(translationFragListener)
+            pagerAdapter.addFragment(translationFragment)
+        }
         pagerAdapter.addFragment(
             ExternalLinksFragment.newInstance(inputText, links as ArrayList<ExternalLink>)
         )
@@ -447,7 +450,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
             }
             is GetLayoutResult.Sentence -> setSentenceLayout(result.translation)
             is GetLayoutResult.DictionarySuccess ->
-                if(requireArguments().getBoolean(WORD_SAVED_KEY)) setDictWithSaveWordLayout(result.word, result.items) else setWiktionaryLayout(result.word, result.items)
+                if(requireArguments().getBoolean(WORD_SAVED_KEY)) setDictWithSaveWordLayout(result.word, result.items) else setDictRemoteWordLayout(result.word, result.items)
             is GetLayoutResult.Error -> {
                 Timber.e(result.exception, "Error getting the layout")
                 showTranslationError(result.exception.message ?: result.exception.toString())
@@ -471,9 +474,14 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
         if (_bindingWord != null) {
             bindingWord.saveIcon.setImageResource(R.drawable.ic_bookmark_border_black_24dp)
         }
-        val oldWord = wordState.value.word ?: return
-        val word = WordUI(oldWord.word, oldWord.lang, oldWord.definition) // Deleted word has same values but no id and notes
-        wordState.value = wordState.value.copy(word = word, dbId = NOT_SAVED_ID)
+        dbWord = null
+        val oldWord = mFoundWords
+        if (oldWord != null) {
+            val word = WordUI(oldWord.word, oldWord.lang, oldWord.definition) // Deleted word has same values but no id and notes
+            wordState.value = wordState.value.copy(word = word, dbId = NOT_SAVED_ID)
+        } else {
+            presenter.onLanguageSpinnerChange(languageFrom, languageToISO)
+        }
         updateDatabaseWord(NOT_SAVED_ID)
         deleteDialogShown.value = false
         editDialogShown.value = false
@@ -540,6 +548,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
             val fragment = pagerAdapter?.fragments?.get(fragIndex)
             val word = Words(inputText ?: "", translation.src, translation.translatedText)
             if (fragment is TranslationFragment) fragment.updateTranslation(word, languagePreferenceIndex)
+            mFoundWords = word
             wordState.value = wordState.value.copy(word = word.toUI())
         } else {
             if(selectedSpans.value != null) selectedSpans.value = null
@@ -677,16 +686,16 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
         }
     }
 
-    private fun setSavedWordToolbar() {
+    private fun setSavedWordToolbar(word: Words) {
         bindingWord.saveIcon.setImageResource(R.drawable.ic_bookmark_black_24dp)
         bindingWord.saveIcon.setOnClickListener { editDialogShown.value = true }
 
         // Hides language from spinner, because language is already predefined.
         bindingWord.spinnerLanguageFrom.visibility = View.INVISIBLE
-        bindingWord.textLanguageCode.text = mFoundWords.lang
+        bindingWord.textLanguageCode.text = word.lang
         bindingWord.textLanguageCode.visibility = View.VISIBLE
 
-        wordState.value = wordState.value.copy(word = mFoundWords.toUI(), dbId = mFoundWords.id)
+        wordState.value = wordState.value.copy(word = word.toUI(), dbId = word.id)
         bindingWord.composeRoot.setContent {
             AppTheme {
                 languages = resources.getStringArray(R.array.googleTranslateLanguagesArray).toList()

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
@@ -255,9 +255,12 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
 
         presenterImp.wordInfo().observe(this) {result ->
             when(result) {
-                is WordResult.Local -> wordState.value = WordState(result.word.toUI(),true, selectedWordSpan)
-                is WordResult.Remote -> wordState.value = WordState(WordUI(result.translation.originalText, result.translation.src, result.translation.translatedText), false, selectedWordSpan)
-                is WordResult.Error -> { Toast.makeText(context, "Error: ${result.exception}", Toast.LENGTH_SHORT).show() }
+                is WordResult.Local -> wordState.value = WordState(result.word.toUI(), result.word.id, selectedWordSpan)
+                is WordResult.Remote -> wordState.value = WordState(WordUI(result.translation.originalText, result.translation.src, result.translation.translatedText), span = selectedWordSpan)
+                is WordResult.Error -> {
+                    Toast.makeText(context, "Couldn't load selected word", Toast.LENGTH_SHORT).show()
+                    Timber.e(result.exception, "Couldn't load selected word info")
+                }
             }
         }
 
@@ -275,7 +278,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
                     if (_bindingWord != null) {
                         setSavedWordToolbar()
                     } else {
-                        wordState.value = wordState.value.copy(word = result.word.toUI(), isSaved = true)
+                        wordState.value = wordState.value.copy(word = result.word.toUI(), dbId = result.word.id)
                     }
                 }
                 ResultType.Update -> editDialogShown.value = false
@@ -352,7 +355,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
         bindingWord.composeRoot.setContent {
             AppTheme {
                 languages = resources.getStringArray(R.array.googleTranslateLanguagesArray).toList()
-                wordState.value = WordState(word.toUI())
+                wordState.value = WordState(word.toUI(), dbId = word.id)
                 EditDeleteWordDialogs(wordState)
             }
         }
@@ -467,11 +470,11 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
     override fun showWordDeleted() {
         if (_bindingWord != null) {
             bindingWord.saveIcon.setImageResource(R.drawable.ic_bookmark_border_black_24dp)
-            wordState.value = wordState.value.copy(isSaved = false)
+            wordState.value = wordState.value.copy(dbId = NOT_SAVED_ID)
         } else {
             val oldWord = wordState.value.word ?: return
-            val word = Words(oldWord.word, oldWord.lang, oldWord.definition) // Deleted word has same values but no id and notes
-            wordState.value = wordState.value.copy(word = word.toUI(), isSaved = false)
+            val word = WordUI(oldWord.word, oldWord.lang, oldWord.definition) // Deleted word has same values but no id and notes
+            wordState.value = wordState.value.copy(word = word, dbId = NOT_SAVED_ID)
         }
         deleteDialogShown.value = false
         editDialogShown.value = false
@@ -683,7 +686,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
         bindingWord.textLanguageCode.text = mFoundWords.lang
         bindingWord.textLanguageCode.visibility = View.VISIBLE
 
-        wordState.value = wordState.value.copy(isSaved = true, word = mFoundWords.toUI())
+        wordState.value = wordState.value.copy(word = mFoundWords.toUI(), dbId = mFoundWords.id)
         bindingWord.composeRoot.setContent {
             AppTheme {
                 languages = resources.getStringArray(R.array.googleTranslateLanguagesArray).toList()
@@ -882,7 +885,9 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
             languagesISO = StringList(languagesISO),
             isSaved = wordState.value.isSaved,
             onSave = {
-                if(wordState.value.isSaved) saveWordViewModel.update(it) else saveWordViewModel.save(it)
+                val resultWord = it.toWord()
+                resultWord.id = wordState.value.dbId
+                if(wordState.value.isSaved) saveWordViewModel.update(resultWord) else saveWordViewModel.save(resultWord)
             },
             onDelete = { deleteDialogShown.value = true },
             onDismiss = { editDialogShown.value = false }

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoScreen.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoScreen.kt
@@ -76,7 +76,6 @@ import com.guillermonegrete.tts.common.compose.Spinner
 import com.guillermonegrete.tts.common.compose.StringList
 import com.guillermonegrete.tts.common.models.Span
 import com.guillermonegrete.tts.common.models.WordUI
-import com.guillermonegrete.tts.db.Words
 import com.guillermonegrete.tts.importtext.visualize.model.SplitPageSpan
 import com.guillermonegrete.tts.ui.theme.AppTheme
 import com.guillermonegrete.tts.ui.theme.YellowNoteHighlight
@@ -379,7 +378,7 @@ fun EditWordDialog(
     languages: StringList,
     languagesISO: StringList,
     isSaved: Boolean = false,
-    onSave: (Words) -> Unit = {},
+    onSave: (WordUI) -> Unit = {},
     onDelete: () -> Unit = {},
     onDismiss: () -> Unit = {},
 ) {
@@ -468,7 +467,7 @@ fun EditWordDialog(
                     Spacer(Modifier.weight(1f))
                     Button(onClick = onDismiss) { Text(text = stringResource(android.R.string.cancel)) }
                     Button(onClick = {
-                        onSave(Words(wordText, languagesISO.items[indexLang], translationText).apply { this.notes = notesText })
+                        onSave(WordUI(wordText, languagesISO.items[indexLang], translationText, notesText))
                     }) {
                         Text(text = stringResource(android.R.string.ok))
                     }
@@ -481,9 +480,11 @@ fun EditWordDialog(
 
 data class WordState(
     val word: WordUI? = null,
-    val isSaved: Boolean = false,
+    val dbId: Int = NOT_SAVED_ID,
     val span: Span? = null,
-)
+) {
+    val isSaved = dbId != NOT_SAVED_ID
+}
 
 data class PlayIconState(
     val isPlaying: Boolean = false,
@@ -531,7 +532,7 @@ fun DarkSentenceDialogWithWordPreview(@PreviewParameter(LoremIpsum::class) text:
             targetLangIndex = 1,
             sourceLangIndex = 0,
             detectedLanguageState = remember { mutableIntStateOf(3) },
-            wordState = remember { mutableStateOf(WordState(WordUI("Original", "en",  "Translation"), true, Span(6, 11))) }
+            wordState = remember { mutableStateOf(WordState(WordUI("Original", "en",  "Translation"), 1, Span(6, 11))) }
         )
     }
 }
@@ -552,3 +553,5 @@ fun EditWordDialogPreview() {
         )
     }
 }
+
+const val NOT_SAVED_ID = 0

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TranslationFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TranslationFragment.kt
@@ -77,11 +77,13 @@ class TranslationFragment: Fragment(R.layout.fragment_process_translation) {
         clipboard.setPrimaryClip(clip)
     }
 
-    fun updateTranslation(word: Words){
+    fun updateTranslation(word: Words, languageIndex: Int){
         if(isAdded) {
             binding.translationText.text = word.definition
+            spinnerIndex = languageIndex
         }else{
             arguments?.putParcelable(ARGUMENT_WORD, word)
+            arguments?.putInt(ARGUMENT_SPINNER_INDEX, languageIndex)
         }
     }
 

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TranslationFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TranslationFragment.kt
@@ -9,13 +9,22 @@ import android.widget.*
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.asFlow
 import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.guillermonegrete.tts.R
 import com.guillermonegrete.tts.databinding.FragmentProcessTranslationBinding
 import com.guillermonegrete.tts.db.Words
 import com.guillermonegrete.tts.db.WordsDAO
 import com.guillermonegrete.tts.ui.DifferentValuesAdapter
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -30,6 +39,9 @@ class TranslationFragment: Fragment(R.layout.fragment_process_translation) {
 
     @Inject lateinit var wordsDAO: WordsDAO
 
+    private var wordJob: Job? = null
+    private val _wordId = MutableStateFlow(0)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         word = arguments?.getParcelable(ARGUMENT_WORD)
@@ -42,25 +54,14 @@ class TranslationFragment: Fragment(R.layout.fragment_process_translation) {
         _binding = FragmentProcessTranslationBinding.bind(view)
 
         word?.let {word ->
-            setWord(word)
 
             // If spinner index is set then it's a sentence layout
-            if(spinnerIndex != -1) {
-                with(binding) {
-                    setSpinner(root)
-                    definitionGroup.isVisible = false
-                    translationGroup.isVisible = true
-                    translationText.text = word.definition
-                    copyTranslationButton.setOnClickListener {
-                        saveTextToClipboard(word.definition)
-                    }
-                }
+            if(word.id == NOT_SAVED_ID) {
+                setSpinnerLayout(word)
             } else {
                 // Only query the database when it's a word layout
-                wordsDAO.loadWordById(word.id).distinctUntilChanged().observe(viewLifecycleOwner) {
-                    it ?: return@observe
-                    setWord(it)
-                }
+                _wordId.value = word.id
+                launchWordJob()
             }
         }
     }
@@ -68,19 +69,6 @@ class TranslationFragment: Fragment(R.layout.fragment_process_translation) {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
-    }
-
-    private fun setWord(word: Words){
-        with(binding){
-            savedDefinitionText.text = word.definition
-            val isEmpty = word.notes.isNullOrBlank()
-            notesGroup.isGone = isEmpty
-            if(!isEmpty) savedNotesText.text = word.notes
-
-            copyDefinitionButton.setOnClickListener {
-                saveTextToClipboard(word.definition)
-            }
-        }
     }
 
     private fun saveTextToClipboard(text: String){
@@ -108,8 +96,32 @@ class TranslationFragment: Fragment(R.layout.fragment_process_translation) {
         this.listener = listener
     }
 
-    private fun setSpinner(root: View) {
-        val spinner = root.findViewById<Spinner>(R.id.translate_to_spinner)
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun launchWordJob() {
+        wordJob = lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+
+                _wordId.flatMapLatest { id ->
+                    wordsDAO.loadWordById(id).distinctUntilChanged().asFlow()
+                }.collect { dbWord ->
+                    if (dbWord == null) {
+                        word?.let { setSpinnerLayout(it) }
+                    } else {
+                        setSavedWordLayout(dbWord)
+                    }
+                }
+            }
+        }
+    }
+
+    fun setWordId(id: Int) {
+        _wordId.value = id
+        if (wordJob == null) {
+            launchWordJob()
+        }
+    }
+
+    private fun setSpinnerLayout(word: Words) {
         val arrayAdapter = DifferentValuesAdapter.createFromResource(
             requireContext(),
             R.array.googleTranslateLanguagesValue,
@@ -119,12 +131,37 @@ class TranslationFragment: Fragment(R.layout.fragment_process_translation) {
         // Specify the layout to use when the list of choices appears
         arrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         // Apply the adapter to the spinner
-        spinner.apply {
-            adapter = arrayAdapter
-            spinnerIndex?.let { setSelection(it, false) }
-            post { onItemSelectedListener = SpinnerListener() } // the post{} avoids the listener being called
-        }
+        with (binding) {
+            translateToSpinner.apply {
+                adapter = arrayAdapter
+                spinnerIndex?.let { setSelection(it, false) }
+                post { onItemSelectedListener = SpinnerListener() } // the post{} avoids the listener being called
+            }
 
+            definitionGroup.isVisible = false
+            notesGroup.isVisible = false
+            translationGroup.isVisible = true
+            translationText.text = word.definition
+            copyTranslationButton.setOnClickListener {
+                saveTextToClipboard(word.definition)
+            }
+        }
+    }
+
+    private fun setSavedWordLayout(word: Words) {
+        with(binding){
+            savedDefinitionText.text = word.definition
+            val isEmpty = word.notes.isNullOrBlank()
+            notesGroup.isGone = isEmpty
+            if(!isEmpty) savedNotesText.text = word.notes
+
+            copyDefinitionButton.setOnClickListener {
+                saveTextToClipboard(word.definition)
+            }
+            definitionGroup.isVisible = true
+            translationGroup.isVisible = false
+            translateToSpinner.adapter = null
+        }
     }
 
     inner class SpinnerListener: AdapterView.OnItemSelectedListener {

--- a/app/src/test/java/com/guillermonegrete/tts/data/source/remote/FakeWordDataSource.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/data/source/remote/FakeWordDataSource.kt
@@ -22,6 +22,11 @@ class FakeWordDataSource: WordDataSource {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 
+    override fun insertWord(word: Words): Int {
+        translationsData[word.id] = word
+        return word.id
+    }
+
     override fun insertWords(vararg words: Words) {
         for(word in words) {
             translationsData[word.id] = word

--- a/app/src/test/java/com/guillermonegrete/tts/savedwords/SaveWordDialogViewModelTest.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/savedwords/SaveWordDialogViewModelTest.kt
@@ -47,6 +47,6 @@ class SaveWordDialogViewModelTest {
         val word = Words("casa", "es", "house new").apply { id = 1 }
         viewModel.update(word)
 
-        assertEquals(ResultType.Update, viewModel.update.getOrAwaitValue())
+        assertEquals(ResultType.Update(word), viewModel.update.getOrAwaitValue())
     }
 }


### PR DESCRIPTION
Several fixes and improvements to the text info dialog:

- Fixed not being able to update a saved word.
- Fixed the edit word dialog not showing the correct information when the database word changed.
- The translation tab now updates correctly the database information, in case the word gets deleted it displays the translation.
- Fixed the spinner in the translation tab not showing the correct preference language.
- Added cache for translations.