### PR TITLE
Feature/#224 saved words visualizer

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,7 +123,7 @@ dependencies {
     implementation "androidx.fragment:fragment-ktx:$fragment_version"
 
     // KTX core
-    implementation "androidx.core:core-ktx:1.2.0"
+    implementation "androidx.core:core-ktx:1.13.1"
 
     // Google custom tabs
     implementation 'androidx.browser:browser:1.0.0'

--- a/app/src/main/java/com/guillermonegrete/tts/common/compose/Composables.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/common/compose/Composables.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -182,8 +184,25 @@ fun ExternalLinksDialog(
 
                 LazyRow(state = listState) {
                     itemsIndexed(links.items) {index, link ->
-                        if (index == selected) {
-                            Box(modifier = Modifier.width(IntrinsicSize.Max)) {
+
+                        Row(
+                            modifier = Modifier.height(IntrinsicSize.Min) // This prevents the divider's height from taking all the space
+                        ) {
+                            if (index == selected) {
+                                Box(modifier = Modifier.width(IntrinsicSize.Max)) {
+                                    TextButton(onClick = {
+                                        selected = index
+                                        coroutineScope.launch { listState.animateScrollToItem(index) }
+                                        onItemClick(index)
+                                    }) {
+                                        Text(text = link.siteName, modifier = Modifier.padding(vertical = 6.dp))
+                                    }
+                                    Divider(
+                                        thickness = 4.dp,
+                                        color = MaterialTheme.colors.primary
+                                    )
+                                }
+                            } else {
                                 TextButton(onClick = {
                                     selected = index
                                     coroutineScope.launch { listState.animateScrollToItem(index) }
@@ -191,19 +210,10 @@ fun ExternalLinksDialog(
                                 }) {
                                     Text(text = link.siteName, modifier = Modifier.padding(vertical = 6.dp))
                                 }
-                                Divider(
-                                    thickness = 4.dp,
-                                    color = MaterialTheme.colors.primary
-                                )
                             }
-                        } else {
-                            TextButton(onClick = {
-                                selected = index
-                                coroutineScope.launch { listState.animateScrollToItem(index) }
-                                onItemClick(index)
-                            }) {
-                                Text(text = link.siteName, modifier = Modifier.padding(vertical = 6.dp))
-                            }
+
+                            if (index < links.items.lastIndex)
+                                Divider(modifier = Modifier.fillMaxHeight().width(1.dp))
                         }
                     }
                 }
@@ -220,8 +230,11 @@ fun DialogList(
     onDismiss: () -> Unit = {},
 ) {
 
-    Dialog(onDismissRequest = onDismiss) {
-        Surface {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(Modifier.padding(horizontal = 16.dp)) {
             Column {
                 if (title != null) {
                     Text(text = title, modifier = Modifier.padding(8.dp), style = MaterialTheme.typography.h5)

--- a/app/src/main/java/com/guillermonegrete/tts/common/compose/Composables.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/common/compose/Composables.kt
@@ -212,6 +212,36 @@ fun ExternalLinksDialog(
     }
 }
 
+@Composable
+fun DialogList(
+    list: List<String>,
+    title: String? = null,
+    onItemSelected: (Int, String) -> Unit = { _, _ -> },
+    onDismiss: () -> Unit = {},
+) {
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface {
+            Column {
+                if (title != null) {
+                    Text(text = title, modifier = Modifier.padding(8.dp), style = MaterialTheme.typography.h5)
+                    Divider()
+                }
+
+                LazyColumn {
+                    itemsIndexed(list) { index, item ->
+                        DropdownMenuItem(onClick = {
+                            onItemSelected(index, item)
+                        }){
+                            Text(text = item)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 @Preview
 @Composable
 fun ExternalLinksDialogPreview() {
@@ -231,5 +261,21 @@ fun SpinnerPreview() {
             Spinner(suggestions)
             Spinner(suggestions, 0)
         }
+    }
+}
+
+@Preview
+@Composable
+fun DialogListPreview() {
+    AppTheme {
+        DialogList(List(3) { "Item ${it + 1}" }, "With title")
+    }
+}
+
+@Preview
+@Composable
+fun DialogListNoTitlePreview() {
+    AppTheme {
+        DialogList(List(3) { "Item ${it + 1}" })
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/db/WordsDAO.java
+++ b/app/src/main/java/com/guillermonegrete/tts/db/WordsDAO.java
@@ -1,5 +1,6 @@
 package com.guillermonegrete.tts.db;
 
+import androidx.annotation.NonNull;
 import androidx.lifecycle.LiveData;
 import androidx.room.Dao;
 import androidx.room.Delete;
@@ -10,11 +11,16 @@ import androidx.room.Update;
 
 import java.util.List;
 
+import kotlinx.coroutines.flow.Flow;
+
 @Dao
 public interface WordsDAO {
 
     @Query("SELECT * FROM words where word = :word LIMIT 1")
     Words findWord(String word);
+
+    @Query("SELECT * FROM words where word in (:words)")
+    Flow<List<Words>> findWords(@NonNull final List<String> words);
 
     @Query("SELECT * FROM words WHERE word = :word AND lang = :language")
     LiveData<Words> loadWord(String word, String language);

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextFragment.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.IntentCompat
 import androidx.core.content.edit
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
@@ -40,6 +41,9 @@ import androidx.core.view.marginTop
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.guillermonegrete.tts.EventObserver
@@ -62,7 +66,9 @@ import com.guillermonegrete.tts.utils.getScreenSizes
 import com.guillermonegrete.tts.webreader.AddNoteDialog
 import com.guillermonegrete.tts.webreader.model.ModifiedNote
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.text.BreakIterator
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -148,7 +154,7 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
         // Creates one item so setPageTransformer is called
         // Used to get the page text view properties to create page splitter.
         viewPager.adapter = VisualizerAdapter(listOf(VisualizerAdapter.PageItem.EMPTY),
-            {}, {}, measuringPage = true) // Empty callbacks, not necessary at the moment]
+            {}, {}, measuringPage = true) // Empty callbacks, not necessary at the moment
 
         viewPager.post{
             addPagerCallback()
@@ -424,6 +430,15 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
                 linksDialogShown.value = true
             }
 
+            lifecycleScope.launch {
+                viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    pageSavedWords.collect { words ->
+                        Timber.d("Found words: $words")
+                    }
+                }
+            }
+
+
             languagesISO = resources.getStringArray(R.array.googleTranslateLanguagesValue)
         }
     }
@@ -431,7 +446,7 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
     private fun initParse() {
         val intent = requireActivity().intent
         if(SHOW_EPUB == intent.action) {
-            val uri: Uri = intent.getParcelableExtra(EPUB_URI) ?: return
+            val uri: Uri = IntentCompat.getParcelableExtra(intent, EPUB_URI, Uri::class.java) ?: return
             val rootStream = requireContext().contentResolver.openInputStream(uri)
             viewModel.fileReader = DefaultZipFileReader(rootStream, requireContext())
             viewModel.fileUri = uri.toString()
@@ -588,6 +603,12 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
                     viewPager.post { pagesAdapter.notifyItemChanged(previousPage, VisualizerAdapter.UNSELECT_SENTENCE) }
                 }
 
+                // Load saved words when reaching new áge
+                val text = pagesAdapter.getPageText(position)
+                val words = splitByWords(text.toString())
+                Timber.d("Split words: $words")
+                viewModel.loadLocalWords(words)
+
                 previousPage = position
             }
 
@@ -628,7 +649,7 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
     }
 
     private fun createPageSplitter(textView: TextView, width: Int): PageSplitter {
-        val uri: Uri? = requireActivity().intent.getParcelableExtra(EPUB_URI)
+        val uri: Uri? = IntentCompat.getParcelableExtra(requireActivity().intent, EPUB_URI, Uri::class.java)
         val imageGetter = if(uri != null) {
             val zipReader = DefaultZipFileReader(requireContext().contentResolver.openInputStream(uri), requireContext())
             InputStreamImageGetter(requireContext(), zipReader)
@@ -899,6 +920,22 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
             }
         }
         return text
+    }
+
+    private fun splitByWords(text: String): List<String> {
+        val words = arrayListOf<String>()
+        val iterator = BreakIterator.getWordInstance()
+        iterator.setText(text)
+        var start = iterator.first()
+        var end = iterator.next()
+
+        while (end != BreakIterator.DONE) {
+            val possibleWord = text.substring(start, end)
+            if (possibleWord.isNotBlank()) words.add(possibleWord)
+            start = end
+            end = iterator.next()
+        }
+        return words
     }
 
     @Composable

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextFragment.kt
@@ -56,10 +56,12 @@ import com.guillermonegrete.tts.common.models.Span
 import com.guillermonegrete.tts.common.models.toUI
 import com.guillermonegrete.tts.databinding.FragmentVisualizeTextBinding
 import com.guillermonegrete.tts.db.ExternalLink
+import com.guillermonegrete.tts.db.Words
 import com.guillermonegrete.tts.importtext.epub.NavPoint
 import com.guillermonegrete.tts.importtext.visualize.model.BookChapter
 import com.guillermonegrete.tts.importtext.visualize.model.SplitPageSpan
 import com.guillermonegrete.tts.textprocessing.TextInfoDialog
+import com.guillermonegrete.tts.textprocessing.WordState
 import com.guillermonegrete.tts.ui.BrightnessTheme
 import com.guillermonegrete.tts.ui.theme.VisualizerTheme
 import com.guillermonegrete.tts.utils.getScreenSizes
@@ -153,8 +155,9 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
         viewPager = binding.textReaderViewpager
         // Creates one item so setPageTransformer is called
         // Used to get the page text view properties to create page splitter.
-        viewPager.adapter = VisualizerAdapter(listOf(VisualizerAdapter.PageItem.EMPTY),
+        pagesAdapter = VisualizerAdapter(listOf(VisualizerAdapter.PageItem.EMPTY),
             {}, {}, measuringPage = true) // Empty callbacks, not necessary at the moment
+        viewPager.adapter = pagesAdapter
 
         viewPager.post{
             addPagerCallback()
@@ -433,7 +436,7 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
             lifecycleScope.launch {
                 viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                     pageSavedWords.collect { words ->
-                        Timber.d("Found words: $words")
+                        highlightSavedWords(words)
                     }
                 }
             }
@@ -441,6 +444,27 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
 
             languagesISO = resources.getStringArray(R.array.googleTranslateLanguagesValue)
         }
+    }
+
+    private fun highlightSavedWords(dbWords: List<Words>) {
+        val text = pagesAdapter.getPageText(viewPager.currentItem).toString()
+        val words = arrayListOf<WordState>()
+
+        val iterator = BreakIterator.getWordInstance()
+        iterator.setText(text)
+        var start = iterator.first()
+        var end = iterator.next()
+
+        while (end != BreakIterator.DONE) {
+            val possibleWord = text.substring(start, end)
+            val dbWord = dbWords.find { it.word == possibleWord }
+            if (dbWord != null) {
+                words.add(WordState(dbWord.toUI(), dbWord.id, Span(start, end)))
+            }
+            start = end
+            end = iterator.next()
+        }
+        pagesAdapter.updateSavedWords(words, viewPager.currentItem)
     }
 
     private fun initParse() {
@@ -606,7 +630,6 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
                 // Load saved words when reaching new áge
                 val text = pagesAdapter.getPageText(position)
                 val words = splitByWords(text.toString())
-                Timber.d("Split words: $words")
                 viewModel.loadLocalWords(words)
 
                 previousPage = position

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextFragment.kt
@@ -48,6 +48,7 @@ import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.guillermonegrete.tts.EventObserver
 import com.guillermonegrete.tts.R
+import com.guillermonegrete.tts.common.compose.DialogList
 import com.guillermonegrete.tts.common.compose.ExternalLinkList
 import com.guillermonegrete.tts.common.compose.ExternalLinksDialog
 import com.guillermonegrete.tts.common.models.EditNote
@@ -101,10 +102,12 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
     private val addNoteDialogVisible = mutableStateOf(false)
     private val noteSheetVisible = mutableStateOf(false)
     private var linksDialogShown = mutableStateOf(false)
+    private val pickInfoDialogVisible = mutableStateOf(false)
     private val wordLinks = mutableStateOf(ExternalLinkList(emptyList()))
     private var selectedLink = 0
 
     private var noteInfo = mutableStateOf<EditNote?>(null)
+    private var clickedWord = ""
 
     private var splitterCreated = false
 
@@ -484,14 +487,24 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
     private fun setUpPagerAndIndexLabel(chapter: BookChapter){
         pagesAdapter = VisualizerAdapter(
             createPageItems(chapter),
-            showTextDialog = ::showTextDialog,
             onCreateNote = {
                 noteInfo.value = it
                 addNoteDialogVisible.value = true
             },
-            onNoteClicked = {
-                noteInfo.value = it
-                noteSheetVisible.value = true
+            onTextClick = { result ->
+                when(result) {
+                    is VisualizerAdapter.TextClick.Note -> {
+                        noteInfo.value = result.note
+                        noteSheetVisible.value = true
+                    }
+                    is VisualizerAdapter.TextClick.SavedWord -> showTextDialog(result.word)
+                    is VisualizerAdapter.TextClick.Overlap -> {
+                        noteInfo.value = result.note
+                        clickedWord = result.word
+                        pickInfoDialogVisible.value = true
+                    }
+                    is VisualizerAdapter.TextClick.Word -> showTextDialog(result.word)
+                }
             },
             getPageCharPos = viewModel::getCharPos
         )
@@ -993,6 +1006,21 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
                 addNoteVisible = false
             },
         )
+        
+        if (pickInfoDialogVisible.value) {
+            DialogList(
+                list = listOf(resources.getString(R.string.note), resources.getString(R.string.saved_word)),
+                title = resources.getString(R.string.pick_info_dialog_title),
+                onItemSelected = { index, _ ->
+                    when (index) {
+                        0 -> noteSheetVisible.value = true
+                        1 -> showTextDialog(clickedWord)
+                    }
+                    pickInfoDialogVisible.value = false
+                },
+                onDismiss = { pickInfoDialogVisible.value = false }
+            )
+        }
     }
 
     @Composable

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModel.kt
@@ -12,6 +12,7 @@ import com.guillermonegrete.tts.data.preferences.SettingsRepository
 import com.guillermonegrete.tts.data.source.FileRepository
 import com.guillermonegrete.tts.db.BookFile
 import com.guillermonegrete.tts.db.ExternalLink
+import com.guillermonegrete.tts.db.WordsDAO
 import com.guillermonegrete.tts.importtext.ImportedFileType
 import com.guillermonegrete.tts.importtext.epub.Book
 import com.guillermonegrete.tts.importtext.visualize.model.BookChapter
@@ -25,6 +26,8 @@ import com.guillermonegrete.tts.webreader.db.NoteDAO
 import com.guillermonegrete.tts.webreader.model.ModifiedNote
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import timber.log.Timber
 import java.io.File
 import java.util.*
@@ -36,6 +39,7 @@ class VisualizeTextViewModel @Inject constructor(
     private val settings: SettingsRepository,
     private val fileRepository: FileRepository,
     private val noteDAO: NoteDAO,
+    private val wordDAO: WordsDAO,
     private val getTranslationInteractor: GetLangAndTranslation,
     private val getExternalLinksInteractor: GetExternalLink,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -124,6 +128,12 @@ class VisualizeTextViewModel @Inject constructor(
                 _translatedPages = arrayOfNulls<Translation>(pagesSize).toMutableList()
             }
         }
+
+    private val pageWords = MutableStateFlow(emptyList<String>())
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val pageSavedWords = pageWords.flatMapLatest { words ->
+        wordDAO.findWords(words)
+    }
 
 
     fun parseEpub() {
@@ -487,6 +497,10 @@ class VisualizeTextViewModel @Inject constructor(
             val links = getExternalLinksInteractor(languageFrom, word)
             _linksForWord.value = links
         }
+    }
+
+    fun loadLocalWords(words: List<String>) {
+        pageWords.value = words
     }
 
 }

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizerAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizerAdapter.kt
@@ -95,6 +95,8 @@ class VisualizerAdapter(
         return R.layout.visualizer_page_item
     }
 
+    fun getPageText(position: Int) = pages.getOrNull(position)?.text
+
     @SuppressLint("ClickableViewAccessibility")
     open inner class ViewHolder(view: View): RecyclerView.ViewHolder(view) {
         protected val pageTextView: TextView = view.findViewById(R.id.page_text_view)

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizerAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizerAdapter.kt
@@ -8,6 +8,7 @@ import android.util.TypedValue
 import android.view.*
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.graphics.ColorUtils
 import androidx.core.widget.TextViewCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.guillermonegrete.tts.R
@@ -17,9 +18,12 @@ import com.guillermonegrete.tts.common.models.Span
 import com.guillermonegrete.tts.databinding.VisualizerPageItemBinding
 import com.guillermonegrete.tts.databinding.VisualizerSplitPageItemBinding
 import com.guillermonegrete.tts.textprocessing.WordState
+import com.guillermonegrete.tts.ui.theme.HighlightColorInt
 import com.guillermonegrete.tts.utils.addHighlightedText
 import com.guillermonegrete.tts.utils.findWordForRightHanded
 import com.guillermonegrete.tts.utils.getSelectedText
+import kotlin.math.max
+import kotlin.math.min
 
 class VisualizerAdapter(
     private val pages: List<PageItem>,
@@ -127,6 +131,18 @@ class VisualizerAdapter(
                 val span = it.span
                 if (span != null) text.addHighlightedText(span.start, span.end)
             }
+
+            // When a note and saved word overlap add a blend of their colors
+            pageItem.notes.forEach { note ->
+                pageItem.savedWords.forEach {
+                    val span = it.span
+                    if (span != null && note.span.intersects(it.span)) {
+                        val start = max(span.start, note.span.start)
+                        val end = min(span.end, note.span.end)
+                        text.addHighlightedText(start, end, ColorUtils.blendARGB(HighlightColorInt, note.color, 0.5f))
+                    }
+                }
+            }
         }
 
         private inner class PageGestureListener : GestureDetector.SimpleOnGestureListener() {
@@ -135,6 +151,12 @@ class VisualizerAdapter(
                 val offset = pageTextView.getOffsetForPosition(e.x, e.y)
 
                 val item = pages[adapterPosition]
+                val savedWord = item.savedWords.find { it.span != null && offset in it.span.start ..it.span.end }
+                if (savedWord != null) {
+                    showTextDialog(savedWord.word?.word ?: "")
+                    return true
+                }
+
                 val clickedNote = item.notes.find { offset in it.span.start .. it.span.end }
                 if (clickedNote != null) {
                     val span = clickedNote.span

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizerAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizerAdapter.kt
@@ -27,9 +27,8 @@ import kotlin.math.min
 
 class VisualizerAdapter(
     private val pages: List<PageItem>,
-    private val showTextDialog: (CharSequence) -> Unit,
     private val onCreateNote: (EditNote) -> Unit,
-    private val onNoteClicked: (EditNote) -> Unit = {},
+    private val onTextClick: (TextClick) -> Unit = {},
     private val getPageCharPos: () -> Int = {0},
     private val measuringPage: Boolean = false
 ): RecyclerView.Adapter<RecyclerView.ViewHolder>() {
@@ -105,7 +104,9 @@ class VisualizerAdapter(
     open inner class ViewHolder(view: View): RecyclerView.ViewHolder(view) {
         protected val pageTextView: TextView = view.findViewById(R.id.page_text_view)
 
-        private val actionModeCallback = PageActionModeCallback(pageTextView, showTextDialog)
+        private val actionModeCallback = PageActionModeCallback(pageTextView) {
+            onTextClick(TextClick.Word(it.toString()))
+        }
 
         init {
             // Color taken from member variable mHighlightColor from TextView class.
@@ -152,17 +153,17 @@ class VisualizerAdapter(
 
                 val item = pages[adapterPosition]
                 val savedWord = item.savedWords.find { it.span != null && offset in it.span.start ..it.span.end }
-                if (savedWord != null) {
-                    showTextDialog(savedWord.word?.word ?: "")
-                    return true
-                }
-
                 val clickedNote = item.notes.find { offset in it.span.start .. it.span.end }
-                if (clickedNote != null) {
-                    val span = clickedNote.span
-                    val text = item.text.substring(span.start, span.end)
-                    val absoluteSpan = Span(item.firstCharIndex + span.start, item.firstCharIndex + span.end)
-                    onNoteClicked(EditNote(text, clickedNote.text, absoluteSpan, clickedNote.color, true, clickedNote.id))
+                if (savedWord != null && clickedNote != null) {
+                    val word = savedWord.word?.word ?: ""
+                    val note = createNote(clickedNote, item)
+                    onTextClick(TextClick.Overlap(note, word))
+                    return true
+                } else if (savedWord != null) {
+                    onTextClick(TextClick.SavedWord(savedWord.word?.word ?: ""))
+                    return true
+                } else if (clickedNote != null) {
+                    onTextClick(TextClick.Note(createNote(clickedNote, item)))
                     return true
                 }
 
@@ -170,7 +171,7 @@ class VisualizerAdapter(
                 val clickedWord = pageTextView.text.substring(wordSpan.start, wordSpan.end)
 
                 if (clickedWord.isNotEmpty()) {
-                    showTextDialog(clickedWord)
+                    onTextClick(TextClick.Word(clickedWord))
                     return true
                 }
 
@@ -355,6 +356,13 @@ class VisualizerAdapter(
         notifyItemChanged(position)
     }
 
+    private fun createNote(clickedNote: NoteItem, item: PageItem): EditNote {
+        val span = clickedNote.span
+        val text = item.text.substring(span.start, span.end)
+        val absoluteSpan = Span(item.firstCharIndex + span.start, item.firstCharIndex + span.end)
+        return EditNote(text, clickedNote.text, absoluteSpan, clickedNote.color, true, clickedNote.id)
+    }
+
     companion object {
         const val UNSELECT_SENTENCE = 10
     }
@@ -374,4 +382,11 @@ class VisualizerAdapter(
     }
 
     data class SentenceHighlight(val span: BackgroundColorSpan, val pos: Span)
+
+    sealed class TextClick {
+        data class Note(val note: EditNote): TextClick()
+        data class SavedWord(val word: String): TextClick()
+        data class Overlap(val note: EditNote, val word: String): TextClick()
+        data class Word(val word: String): TextClick()
+    }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizerAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizerAdapter.kt
@@ -221,6 +221,12 @@ class VisualizerAdapter(
                 if (start < noteSpan.end && end > noteSpan.start)
                     text.addHighlightedText(noteSpan.start, noteSpan.end, it.color)
             }
+            item.savedWords.forEach {
+                val noteSpan = it.span
+                if (noteSpan != null && start < noteSpan.end && end > noteSpan.start)
+                    text.addHighlightedText(noteSpan.start, noteSpan.end)
+            }
+
             pageTextView.setText(text, TextView.BufferType.SPANNABLE)
         }
 

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizerAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizerAdapter.kt
@@ -8,7 +8,6 @@ import android.util.TypedValue
 import android.view.*
 import android.widget.LinearLayout
 import android.widget.TextView
-import androidx.core.view.GestureDetectorCompat
 import androidx.core.widget.TextViewCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.guillermonegrete.tts.R
@@ -17,6 +16,7 @@ import com.guillermonegrete.tts.common.models.NoteItem
 import com.guillermonegrete.tts.common.models.Span
 import com.guillermonegrete.tts.databinding.VisualizerPageItemBinding
 import com.guillermonegrete.tts.databinding.VisualizerSplitPageItemBinding
+import com.guillermonegrete.tts.textprocessing.WordState
 import com.guillermonegrete.tts.utils.addHighlightedText
 import com.guillermonegrete.tts.utils.findWordForRightHanded
 import com.guillermonegrete.tts.utils.getSelectedText
@@ -106,7 +106,7 @@ class VisualizerAdapter(
         init {
             // Color taken from member variable mHighlightColor from TextView class.
             pageTextView.highlightColor = 0x6633B5E5
-            val detector = GestureDetectorCompat(itemView.context, PageGestureListener())
+            val detector = GestureDetector(itemView.context, PageGestureListener())
             pageTextView.setOnTouchListener { _, event ->
                 detector.onTouchEvent(event)
             }
@@ -115,6 +115,18 @@ class VisualizerAdapter(
 
         open fun bind(pageItem: PageItem) {
             actionModeCallback.item = pageItem
+        }
+
+        protected fun addHighlightItems(pageItem: PageItem, text: Spannable) {
+            pageItem.notes.forEach {
+                val span = it.span
+                text.addHighlightedText(span.start, span.end, it.color)
+            }
+
+            pageItem.savedWords.forEach {
+                val span = it.span
+                if (span != null) text.addHighlightedText(span.start, span.end)
+            }
         }
 
         private inner class PageGestureListener : GestureDetector.SimpleOnGestureListener() {
@@ -152,11 +164,7 @@ class VisualizerAdapter(
         override fun bind(pageItem: PageItem){
             super.bind(pageItem)
             val spannable = SpannableString(pageItem.text)
-
-            pageItem.notes.forEach {
-                val span = it.span
-                spannable.addHighlightedText(span.start, span.end, it.color)
-            }
+            addHighlightItems(pageItem, spannable)
             pageTextView.setText(spannable, TextView.BufferType.SPANNABLE)
         }
     }
@@ -179,10 +187,7 @@ class VisualizerAdapter(
                 spannable.setSpan(it.span, it.pos.start, it.pos.end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
             }
 
-            pageItem.notes.forEach {
-                val span = it.span
-                spannable.addHighlightedText(span.start, span.end, it.color)
-            }
+            addHighlightItems(pageItem, spannable)
             pageTextView.setText(spannable, TextView.BufferType.SPANNABLE)
         }
 
@@ -310,9 +315,16 @@ class VisualizerAdapter(
             note != null
         }
         if (pos == -1) return
-        val paragraphItem = pages[pos]
-        paragraphItem.notes.removeAll { noteId == it.id }
+        val pageItem = pages[pos]
+        pageItem.notes.removeAll { noteId == it.id }
         notifyItemChanged(pos)
+    }
+
+    fun updateSavedWords(words: List<WordState>, position: Int) {
+        val pageItem = pages[position]
+        pageItem.savedWords.clear()
+        pageItem.savedWords.addAll(words)
+        notifyItemChanged(position)
     }
 
     companion object {
@@ -326,6 +338,7 @@ class VisualizerAdapter(
          * The index of the paragraph's first char with respect to the whole text.
          */
         val firstCharIndex: Int,
+        val savedWords: MutableList<WordState> = mutableListOf(),
     ) {
         companion object {
             val EMPTY = PageItem("", mutableListOf(), 0)

--- a/app/src/main/java/com/guillermonegrete/tts/ui/theme/Color.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/ui/theme/Color.kt
@@ -1,6 +1,7 @@
 package com.guillermonegrete.tts.ui.theme
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 
 val GreenLight = Color(0xFF28C7BB)
 val GreenDark = Color(0xFF00968b)
@@ -12,3 +13,6 @@ val YellowNoteHighlight = Color(0xAAFDC817)
 val RedNoteHighlight = Color(0xAAFF0000)
 val GreenNoteHighlight = Color(0xAA00FF00)
 val BlueNoteHighlight = Color(0xAA0093FF)
+
+val HighlightColor = Color( 255, 0, 0, 128)
+val HighlightColorInt = HighlightColor.toArgb()

--- a/app/src/main/java/com/guillermonegrete/tts/utils/TextViewExt.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/utils/TextViewExt.kt
@@ -1,14 +1,15 @@
 package com.guillermonegrete.tts.utils
 
-import android.graphics.Color
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.method.ScrollingMovementMethod
 import android.text.style.BackgroundColorSpan
 import android.view.MotionEvent
 import android.widget.TextView
+import androidx.annotation.ColorInt
 import androidx.appcompat.widget.AppCompatTextView
 import com.guillermonegrete.tts.common.models.Span
+import com.guillermonegrete.tts.ui.theme.HighlightColorInt
 
 /**
  * Finds the word in the text view for the given [offset] obtained using [TextView.getOffsetForPosition].
@@ -84,13 +85,17 @@ fun AppCompatTextView.makeScrollableInsideScrollView() {
     }
 }
 
-fun TextView.addHighlightedText(start: Int, end: Int, color: Int = Color.argb(128, 255, 0, 0)){
+fun TextView.addHighlightedText(start: Int, end: Int, @ColorInt color: Int = HighlightColorInt){
     val text = SpannableString(this.text)
 
     text.setSpan(BackgroundColorSpan(color), start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
     this.setText(text, TextView.BufferType.SPANNABLE)
 }
 
-fun Spannable.addHighlightedText(start: Int, end: Int, color: Int = Color.argb(128, 255, 0, 0)){
+fun Spannable.addHighlightedText(
+    start: Int,
+    end: Int,
+    @ColorInt color: Int = HighlightColorInt
+){
     setSpan(BackgroundColorSpan(color), start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
 }

--- a/app/src/main/res/layout/activity_visualize_text.xml
+++ b/app/src/main/res/layout/activity_visualize_text.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main_fragment_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:name="androidx.navigation.fragment.NavHostFragment"
-    app:defaultNavHost="true" />
+    app:defaultNavHost="true"
+    tools:layout="@layout/fragment_visualize_text" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,9 @@
     <string name="yes">Yes</string>
     <string name="cancel">Cancel</string>
 
+    <string name="note">Note</string>
+    <string name="saved_word">Saved word</string>
+
     <string name="play_tts_icon_description">Play TTS</string>
     <string name="edit_icon_description">Edit</string>
     <string name="save_icon_description">Save word</string>
@@ -238,5 +241,6 @@
     <string name="split_page">Split page</string>
     <string name="book_language_label">Book language:</string>
     <string name="translate_to_label">Translate to:</string>
+    <string name="pick_info_dialog_title">Show information for:</string>
 
 </resources>

--- a/app/src/test/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModelTest.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextViewModelTest.kt
@@ -10,6 +10,7 @@ import com.guillermonegrete.tts.data.preferences.FakeSettingsRepository
 import com.guillermonegrete.tts.data.source.FakeFileRepository
 import com.guillermonegrete.tts.data.source.FakeWordRepository
 import com.guillermonegrete.tts.db.BookFile
+import com.guillermonegrete.tts.db.WordsDAO
 import com.guillermonegrete.tts.getOrAwaitValue
 import com.guillermonegrete.tts.getUnitLiveDataValue
 import com.guillermonegrete.tts.importtext.ImportedFileType
@@ -19,6 +20,8 @@ import com.guillermonegrete.tts.main.domain.interactors.GetLangAndTranslation
 import com.guillermonegrete.tts.textprocessing.domain.interactors.GetExternalLink
 import com.guillermonegrete.tts.threading.TestMainThread
 import com.guillermonegrete.tts.webreader.db.FakeNoteDAO
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -51,6 +54,7 @@ class VisualizeTextViewModelTest {
 
     @Mock private lateinit var epubParser: EpubParser
     @Mock private lateinit var fileReader: DefaultZipFileReader
+    @MockK private lateinit var wordDao: WordsDAO
     private lateinit var fileRepository: FakeFileRepository
     private lateinit var wordRepository: FakeWordRepository
     private lateinit var notesDAO: FakeNoteDAO
@@ -69,6 +73,7 @@ class VisualizeTextViewModelTest {
     @Before
     fun setUp(){
         MockitoAnnotations.openMocks(this)
+        MockKAnnotations.init(this)
 
         fileRepository = FakeFileRepository()
         wordRepository = FakeWordRepository()
@@ -78,13 +83,13 @@ class VisualizeTextViewModelTest {
         val getTranslationInteractor = GetLangAndTranslation(TestThreadExecutor(), TestMainThread(), wordRepository)
         val getExternalLinks = GetExternalLink(TestThreadExecutor(), TestMainThread(), mockk(), mainCoroutineRule.dispatcher)
 
-        viewModel = VisualizeTextViewModel(epubParser, settingsRepository, fileRepository, notesDAO, getTranslationInteractor, getExternalLinks, mainCoroutineRule.dispatcher)
+        viewModel = VisualizeTextViewModel(epubParser, settingsRepository, fileRepository, notesDAO, wordDao, getTranslationInteractor, getExternalLinks, mainCoroutineRule.dispatcher)
         viewModel.pageSplitter = pageSplitter
         viewModel.fileReader = fileReader
 
         bookFile.apply {
             chapter = 0
-            page = 0
+            lastChar = 0
         }
     }
 
@@ -292,7 +297,7 @@ class VisualizeTextViewModelTest {
         // Set up with saved values
         val initialPage = 2
         val initialChapter = 3
-        bookFile.page = initialPage
+
         bookFile.chapter = initialChapter
         fileRepository.addFiles(bookFile)
 
@@ -323,7 +328,8 @@ class VisualizeTextViewModelTest {
 
         splitPages(7)
 
-        // Swipe to right three times
+        // Swipe to right four times
+        viewModel.swipeChapterRight()
         viewModel.swipeChapterRight()
         viewModel.swipeChapterRight()
         viewModel.swipeChapterRight()
@@ -336,7 +342,7 @@ class VisualizeTextViewModelTest {
         val uuid = "random"
         viewModel.saveBookData(lastReadDate, uuid)
 
-        val sumPreviousChars = sumCharacters(3, initialPage)
+        val sumPreviousChars = sumCharacters(4, initialPage)
 
         val expectedFile = BookFile(
             uri,
@@ -344,7 +350,7 @@ class VisualizeTextViewModelTest {
             ImportedFileType.EPUB,
             folderPath = uuid,
             lastChar = 50,
-            chapter = 3,
+            chapter = 4,
             percentageDone = 100 * sumPreviousChars / DEFAULT_BOOK.totalChars,
             lastRead = lastReadDate
         )


### PR DESCRIPTION
Closes #224.

It shows the text info dialog instead of a bottom sheet. When a note and a saved word overlap their colors are blended and touching the overlap shows a dialog asking whether to show the information of the word or the saved word. 
Also, shows vertical dividers in the links list of the compose external links dialog.
