### PR TITLE
Fixed crash when the SD is ejected or corrupted.

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/DefaultZipFileReader.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/DefaultZipFileReader.kt
@@ -1,10 +1,8 @@
 package com.guillermonegrete.tts.importtext.visualize
 
-import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.os.Environment
-import androidx.core.content.ContextCompat
+import com.guillermonegrete.tts.importtext.visualize.io.EpubFileManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.apache.commons.io.IOUtils
@@ -13,14 +11,14 @@ import java.util.zip.ZipInputStream
 import kotlin.math.roundToInt
 
 
-class DefaultZipFileReader(inputStream: InputStream?, context: Context): ZipFileReader {
+class DefaultZipFileReader(inputStream: InputStream?, fileManager: EpubFileManager): ZipFileReader {
 
     private val byteStream: ByteArrayInputStream
     private var shouldResetStream = false
 
     private val rootDir: File
     private val filesDir
-        get() = File(rootDir.absolutePath + File.separator + volumes_folder)
+        get() = File(rootDir.absolutePath + File.separator + VOLUMES_FOLDER)
 
     init {
         val baos = ByteArrayOutputStream()
@@ -29,17 +27,7 @@ class DefaultZipFileReader(inputStream: InputStream?, context: Context): ZipFile
         byteStream = ByteArrayInputStream(bytes)
 
         // Initialize files dir
-        val state = Environment.getExternalStorageState()
-        rootDir = if (Environment.MEDIA_MOUNTED == state) {
-
-            val dirs = ContextCompat.getExternalFilesDirs(context, null)
-            // Dirs[0] ==> (emulated)
-            // Dirs[1] ==> (SD card)
-            val dir = if(dirs.size == 2) dirs[1] else dirs[0]
-            dir
-        } else {
-            context.filesDir
-        }
+        rootDir = fileManager.rootDir
     }
 
     override suspend fun getFileStream(filePath: String): InputStream?{
@@ -98,7 +86,7 @@ class DefaultZipFileReader(inputStream: InputStream?, context: Context): ZipFile
 
     override suspend fun createFileFolder(path: String) {
         withContext(Dispatchers.IO) {
-            val dir = File(rootDir.absolutePath + File.separator + volumes_folder, path)
+            val dir = File(rootDir.absolutePath + File.separator + VOLUMES_FOLDER, path)
             if (!dir.exists()) dir.mkdirs()
         }
     }
@@ -152,6 +140,6 @@ class DefaultZipFileReader(inputStream: InputStream?, context: Context): ZipFile
     }
 
     companion object{
-        const val volumes_folder = "volumes"
+        const val VOLUMES_FOLDER = "volumes"
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextFragment.kt
@@ -57,6 +57,7 @@ import com.guillermonegrete.tts.databinding.FragmentVisualizeTextBinding
 import com.guillermonegrete.tts.db.ExternalLink
 import com.guillermonegrete.tts.db.Words
 import com.guillermonegrete.tts.importtext.epub.NavPoint
+import com.guillermonegrete.tts.importtext.visualize.io.EpubFileManager
 import com.guillermonegrete.tts.importtext.visualize.model.BookChapter
 import com.guillermonegrete.tts.importtext.visualize.model.SplitPageSpan
 import com.guillermonegrete.tts.textprocessing.TextInfoDialog
@@ -94,6 +95,8 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
     lateinit var preferences: SharedPreferences
     @Inject
     lateinit var brightnessTheme: BrightnessTheme
+    @Inject
+    lateinit var fileManager: EpubFileManager
     @StyleRes
     private var themeRes = R.style.AppMaterialTheme_Black
 
@@ -465,7 +468,7 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
         if(SHOW_EPUB == intent.action) {
             val uri: Uri = IntentCompat.getParcelableExtra(intent, EPUB_URI, Uri::class.java) ?: return
             val rootStream = requireContext().contentResolver.openInputStream(uri)
-            viewModel.fileReader = DefaultZipFileReader(rootStream, requireContext())
+            viewModel.fileReader = DefaultZipFileReader(rootStream, fileManager)
             viewModel.fileUri = uri.toString()
             viewModel.fileId = intent.getIntExtra(FILE_ID, -1)
             viewModel.parseEpub()
@@ -677,7 +680,7 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
     private fun createPageSplitter(textView: TextView, width: Int): PageSplitter {
         val uri: Uri? = IntentCompat.getParcelableExtra(requireActivity().intent, EPUB_URI, Uri::class.java)
         val imageGetter = if(uri != null) {
-            val zipReader = DefaultZipFileReader(requireContext().contentResolver.openInputStream(uri), requireContext())
+            val zipReader = DefaultZipFileReader(requireContext().contentResolver.openInputStream(uri), fileManager)
             InputStreamImageGetter(requireContext(), zipReader)
         } else null
 

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextFragment.kt
@@ -463,12 +463,16 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
         pagesAdapter.updateSavedWords(words, viewPager.currentItem)
     }
 
-    private fun initParse() {
+    private fun initParse(fileReader: DefaultZipFileReader?) {
         val intent = requireActivity().intent
         if(SHOW_EPUB == intent.action) {
+            if (fileReader == null) {
+                Toast.makeText(context, "Couldn't open file", Toast.LENGTH_SHORT).show()
+                requireActivity().finish()
+                return
+            }
             val uri: Uri = IntentCompat.getParcelableExtra(intent, EPUB_URI, Uri::class.java) ?: return
-            val rootStream = requireContext().contentResolver.openInputStream(uri)
-            viewModel.fileReader = DefaultZipFileReader(rootStream, fileManager)
+            viewModel.fileReader = fileReader
             viewModel.fileUri = uri.toString()
             viewModel.fileId = intent.getIntExtra(FILE_ID, -1)
             viewModel.parseEpub()
@@ -671,20 +675,25 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text) {
             createViewModel()
 
             val pageTextView: TextView = focusedView.findViewById(R.id.page_text_view)
-            viewModel.pageSplitter = createPageSplitter(pageTextView, focusedView.width)
-            initParse()
+            val fileReader = createFileReader()
+            val splitter = if (fileReader != null) InputStreamImageGetter(requireContext(), fileReader) else null
+            viewModel.pageSplitter = PageSplitter(pageTextView, focusedView.width, splitter)
+            initParse(fileReader)
             splitterCreated = true
         }
     }
 
-    private fun createPageSplitter(textView: TextView, width: Int): PageSplitter {
-        val uri: Uri? = IntentCompat.getParcelableExtra(requireActivity().intent, EPUB_URI, Uri::class.java)
-        val imageGetter = if(uri != null) {
-            val zipReader = DefaultZipFileReader(requireContext().contentResolver.openInputStream(uri), fileManager)
-            InputStreamImageGetter(requireContext(), zipReader)
-        } else null
-
-        return PageSplitter(textView, width, imageGetter)
+    private fun createFileReader(): DefaultZipFileReader? {
+        val uri = IntentCompat.getParcelableExtra(requireActivity().intent, EPUB_URI, Uri::class.java)
+        if (uri != null) {
+            try {
+                val stream = requireContext().contentResolver.openInputStream(uri)
+                return DefaultZipFileReader(stream, fileManager)
+            } catch (e: Exception) {
+                Timber.e(e, "Couldn't open URI stream")
+            }
+        }
+        return null
     }
 
     private fun showTableOfContents(navPoints: List<NavPoint>){

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/io/DefaultEpubFileManager.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/io/DefaultEpubFileManager.kt
@@ -19,8 +19,8 @@ class DefaultEpubFileManager @Inject constructor(@ApplicationContext context: Co
 
             val dirs = ContextCompat.getExternalFilesDirs(context, null)
             // Dirs[0] ==> (emulated)
-            // Dirs[1] ==> (SD card)
-            val dir = if(dirs.size == 2) dirs[1] else dirs[0]
+            // Dirs[1] ==> (SD card) // might be null if the card was ejected
+            val dir = if(dirs.size == 2 && dirs[1] != null) dirs[1] else dirs[0]
             dir
         } else {
             context.filesDir


### PR DESCRIPTION
Closes #273.
Also handles when the ebook URI doesn't point to an existing file.