### PR TITLE
Fixed wrong icon for TTS button in sentence layout.

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
@@ -246,7 +246,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
                 StatusTTS.LanguageReady -> true
                 StatusTTS.Unavailable -> false
             }
-            playIconState.value = playIconState.value.copy(isLoading = false, isPlaying = available)
+            playIconState.value = playIconState.value.copy(isLoading = false, isTTSAvailable = available)
         }
 
         val extraWord = BundleCompat.getParcelable(requireArguments(), WORD_KEY, Words::class.java)


### PR DESCRIPTION
The icon was wrong when the TTS wasn't available and when the TTS didn't play automatically. Also, the toast for TTS unavailable wasn't showing.