### PR TITLE
Feature/#261 wiktionary performance

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -141,7 +141,6 @@ dependencies {
     // Retrofit
     def retrofit_version = "2.11.0"
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
-    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofit_version"
 
     implementation "com.squareup.moshi:moshi-kotlin:1.15.2"

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/local/AssetsExternalLinksSource.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/local/AssetsExternalLinksSource.kt
@@ -1,46 +1,47 @@
 package com.guillermonegrete.tts.data.source.local
 
 import android.app.Application
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
-import com.google.gson.stream.JsonReader
 import com.guillermonegrete.tts.data.source.ExternalLinksDataSource
 import com.guillermonegrete.tts.db.ExternalLink
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import okio.buffer
+import okio.source
 import java.lang.Exception
 
-class AssetsExternalLinksSource(private val appContext: Application): ExternalLinksDataSource {
+class AssetsExternalLinksSource(
+    private val appContext: Application,
+    moshi: Moshi
+): ExternalLinksDataSource {
+
+    private val adapter = moshi.adapter<List<ExternalLink>>(Types.newParameterizedType(List::class.java, ExternalLink::class.java))
 
     override fun getLanguageLinks(language: String, callback: ExternalLinksDataSource.Callback) {
-        val linkType = object : TypeToken<List<ExternalLink>>() {}.type
-        var jsonReader: JsonReader? = null
 
         try {
             val inputStream = appContext.assets.open(EXTERNAL_LINKS_DATA_FILENAME)
-            jsonReader = JsonReader(inputStream.reader())
-            val linkList: List<ExternalLink> = Gson().fromJson(jsonReader, linkType)
+            val linkList: List<ExternalLink>? = adapter.fromJson(inputStream.source().buffer())
+            if (linkList == null) {
+                callback.onLinksRetrieved(emptyList())
+                return
+            }
             callback.onLinksRetrieved(linkList.filter { it.language == language })
         } catch (ex: Exception){
-            println("Error loading asset $ex")
+            println("Error loading asset ${ex.message}")
             callback.onLinksRetrieved(emptyList())
-        } finally {
-            jsonReader?.close()
         }
     }
 
     override fun getLanguageLinks(language: String): List<ExternalLink> {
-        val linkType = object : TypeToken<List<ExternalLink>>() {}.type
-        var jsonReader: JsonReader? = null
 
         return try {
             val inputStream = appContext.assets.open(EXTERNAL_LINKS_DATA_FILENAME)
-            jsonReader = JsonReader(inputStream.reader())
-            val linkList: List<ExternalLink> = Gson().fromJson(jsonReader, linkType)
+            val linkList: List<ExternalLink>? = adapter.fromJson(inputStream.source().buffer())
+            if (linkList == null) return emptyList()
             linkList.filter { it.language == language }
         } catch (ex: Exception){
-            println("Error loading asset $ex")
+            println("Error loading asset ${ex.message}")
             emptyList()
-        } finally {
-            jsonReader?.close()
         }
     }
 

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/remote/WiktionaryAPI.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/remote/WiktionaryAPI.java
@@ -6,6 +6,6 @@ import retrofit2.http.Query;
 
 public interface WiktionaryAPI {
 
-    @GET("api.php?action=parse&prop=text&format=json&redirects=1&formatversion=2")
-    Call<WiktionaryResponse> getDefinition(@Query("page") String word);
+    @GET("api.php?action=query&prop=extracts&format=json&explaintext=&redirects=1")
+    Call<WiktionaryResponse> getDefinition(@Query("titles") String word);
 }

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/remote/WiktionaryResponse.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/remote/WiktionaryResponse.java
@@ -3,32 +3,85 @@ package com.guillermonegrete.tts.data.source.remote;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.TreeMap;
+
+// https://stackoverflow.com/questions/33758601/parse-dynamic-key-json-string-using-retrofit
 public class WiktionaryResponse {
 
-    @SerializedName("parse")
+    @SerializedName("query")
     @Expose
-    private Parse parse;
+    private Query query;
 
-    public Parse getParse() {
-        return parse;
+    public Query getQuery() {
+        return query;
     }
 
-    public void setParse(Parse parse) {
-        this.parse = parse;
+    public void setQuery(Query query) {
+        this.query = query;
     }
 
-    public static class Parse {
+    public static class Query {
 
-        @SerializedName("text")
+        @SerializedName("pages")
         @Expose
-        private String text;
+        private TreeMap<String, PageInfo> pageNumber;
 
-        public String getText() {
-            return text;
+        public TreeMap<String, PageInfo> getPageNumber() {
+            return pageNumber;
         }
 
-        public void setText(String text) {
-            this.text = text;
+        public void setPageNumber(TreeMap<String, PageInfo> pageNumber) {
+            this.pageNumber = pageNumber;
         }
+
+    }
+
+    public static class PageInfo {
+
+        @SerializedName("pageid")
+        @Expose
+        private Integer pageid;
+        @SerializedName("ns")
+        @Expose
+        private Integer ns;
+        @SerializedName("title")
+        @Expose
+        private String title;
+        @SerializedName("extract")
+        @Expose
+        private String extract;
+
+        public Integer getPageid() {
+            return pageid;
+        }
+
+        public void setPageid(Integer pageid) {
+            this.pageid = pageid;
+        }
+
+        public Integer getNs() {
+            return ns;
+        }
+
+        public void setNs(Integer ns) {
+            this.ns = ns;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getExtract() {
+            return extract;
+        }
+
+        public void setExtract(String extract) {
+            this.extract = extract;
+        }
+
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/remote/WiktionaryResponse.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/remote/WiktionaryResponse.java
@@ -1,15 +1,12 @@
 package com.guillermonegrete.tts.data.source.remote;
 
-import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.SerializedName;
+import com.squareup.moshi.Json;
 
-import java.util.TreeMap;
+import java.util.Map;
 
 // https://stackoverflow.com/questions/33758601/parse-dynamic-key-json-string-using-retrofit
 public class WiktionaryResponse {
 
-    @SerializedName("query")
-    @Expose
     private Query query;
 
     public Query getQuery() {
@@ -22,15 +19,14 @@ public class WiktionaryResponse {
 
     public static class Query {
 
-        @SerializedName("pages")
-        @Expose
-        private TreeMap<String, PageInfo> pageNumber;
+        @Json(name="pages")
+        private Map<String, PageInfo> pageNumber;
 
-        public TreeMap<String, PageInfo> getPageNumber() {
+        public Map<String, PageInfo> getPageNumber() {
             return pageNumber;
         }
 
-        public void setPageNumber(TreeMap<String, PageInfo> pageNumber) {
+        public void setPageNumber(Map<String, PageInfo> pageNumber) {
             this.pageNumber = pageNumber;
         }
 
@@ -38,17 +34,9 @@ public class WiktionaryResponse {
 
     public static class PageInfo {
 
-        @SerializedName("pageid")
-        @Expose
         private Integer pageid;
-        @SerializedName("ns")
-        @Expose
         private Integer ns;
-        @SerializedName("title")
-        @Expose
         private String title;
-        @SerializedName("extract")
-        @Expose
         private String extract;
 
         public Integer getPageid() {

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/remote/WiktionarySource.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/remote/WiktionarySource.java
@@ -1,22 +1,19 @@
 package com.guillermonegrete.tts.data.source.remote;
 
-import android.os.Build;
-import android.text.Html;
-import android.text.Spanned;
-
 import androidx.annotation.NonNull;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.guillermonegrete.tts.textprocessing.domain.model.WikiItem;
 import com.guillermonegrete.tts.textprocessing.domain.model.WiktionaryItem;
+import com.guillermonegrete.tts.textprocessing.domain.model.WiktionaryLangHeader;
 import com.guillermonegrete.tts.data.source.DictionaryDataSource;
 
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import okhttp3.OkHttpClient;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -29,13 +26,14 @@ public class WiktionarySource implements DictionaryDataSource {
 
     private final WiktionaryAPI wiktionaryAPI;
 
-    public WiktionarySource(){
+    public WiktionarySource(OkHttpClient client){
         Gson gson = new GsonBuilder()
                 .setLenient()
                 .create();
 
-        Retrofit retrofit = new Retrofit.Builder()
+        var retrofit = new Retrofit.Builder()
                 .baseUrl(BASE_URL)
+                .client(client)
                 .addConverterFactory(GsonConverterFactory.create(gson))
                 .build();
 
@@ -52,13 +50,17 @@ public class WiktionarySource implements DictionaryDataSource {
 
                 if (response.isSuccessful() && response.body() != null) {
 
-                    var parseAction = response.body().getParse();
-                    if(parseAction != null) {
-                        String htmlText = parseAction.getText();
-                        var items = WiktionaryParser.parse(htmlText);
+                    var pageEntry = response.body().getQuery().getPageNumber().firstEntry();
+                    if (pageEntry == null) {
+                        callback.onDataNotAvailable();
+                        return;
+                    }
+
+                    var info = pageEntry.getValue();
+                    if (info.getExtract() != null) {
+                        List<WikiItem> items = WiktionaryParser.parse(info.getExtract());
                         callback.onDefinitionLoaded(items);
                     } else {
-                        // If the word doesn't exist then parse is null
                         callback.onDataNotAvailable();
                     }
                 } else {
@@ -76,28 +78,45 @@ public class WiktionarySource implements DictionaryDataSource {
 
     public static class WiktionaryParser {
 
-        public static List<WikiItem> parse(String htmlText) {
-            Document doc = Jsoup.parse(htmlText);
-            // Remove table of contents at the start
-            var toc = doc.getElementById("toc");
-            if (toc != null) toc.remove();
-            // Remove all the edit buttons/text
-            var editSections = doc.getElementsByClass("mw-editsection");
-            if (editSections != null) editSections.remove();
-            CharSequence info = formatHtml(doc.outerHtml());
-            return List.of(new WiktionaryItem(info, ""));
-        }
-    }
+        public static List<WikiItem> parse(String text){
+            List<String> languageSections = getLanguages(text);
+            List<WikiItem> items = new ArrayList<>();
 
-    /**
-     * Format the raw xhtml text to get a more accurate length of the text.
-     */
-    private static Spanned formatHtml(CharSequence text) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            return Html.fromHtml(text.toString(), Html.FROM_HTML_MODE_COMPACT);
-        } else {
-            //noinspection deprecation
-            return Html.fromHtml(text.toString());
+            for (String languageSection: languageSections){
+                String[] separated = languageSection.split("\n=== ");
+                String lang = separated[0].split(" ")[0];
+
+                items.add(new WiktionaryLangHeader(lang));
+
+                List<String> langSubHeaders = new ArrayList<>(Arrays.asList(separated));
+                langSubHeaders.remove(0);
+
+                for (String langSubHeader: langSubHeaders){
+                    String[] subHeaders = langSubHeader.split(" ===\n");
+                    String subHeader = subHeaders[0];
+
+                    if(subHeaders.length > 1) {
+                        String subHeaderContent = subHeaders[1];
+
+                        // We remove undesirable equals
+                        String firstFilter = subHeaderContent.replace("=====", "");
+                        String itemBodyText = firstFilter.replace("====", "");
+
+                        items.add(new WiktionaryItem(itemBodyText, subHeader));
+                    } else { // Because some headers don't have text body
+                        items.add(new WiktionaryItem("", subHeader.replace("===", "")));
+                    }
+                }
+            }
+
+            return items;
+        }
+
+        public static List<String> getLanguages(String extract){
+            String[] separated = extract.split("\n== ");
+            List<String> langs = new ArrayList<>(Arrays.asList(separated));
+            langs.remove(0);
+            return langs;
         }
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/data/source/remote/WiktionarySource.java
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/remote/WiktionarySource.java
@@ -2,12 +2,11 @@ package com.guillermonegrete.tts.data.source.remote;
 
 import androidx.annotation.NonNull;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.guillermonegrete.tts.textprocessing.domain.model.WikiItem;
 import com.guillermonegrete.tts.textprocessing.domain.model.WiktionaryItem;
 import com.guillermonegrete.tts.textprocessing.domain.model.WiktionaryLangHeader;
 import com.guillermonegrete.tts.data.source.DictionaryDataSource;
+import com.squareup.moshi.Moshi;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,7 +17,7 @@ import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 import retrofit2.Retrofit;
-import retrofit2.converter.gson.GsonConverterFactory;
+import retrofit2.converter.moshi.MoshiConverterFactory;
 
 public class WiktionarySource implements DictionaryDataSource {
 
@@ -26,15 +25,11 @@ public class WiktionarySource implements DictionaryDataSource {
 
     private final WiktionaryAPI wiktionaryAPI;
 
-    public WiktionarySource(OkHttpClient client){
-        Gson gson = new GsonBuilder()
-                .setLenient()
-                .create();
-
+    public WiktionarySource(OkHttpClient client, Moshi moshi){
         var retrofit = new Retrofit.Builder()
                 .baseUrl(BASE_URL)
                 .client(client)
-                .addConverterFactory(GsonConverterFactory.create(gson))
+                .addConverterFactory(MoshiConverterFactory.create(moshi))
                 .build();
 
         wiktionaryAPI = retrofit.create(WiktionaryAPI.class);
@@ -50,7 +45,7 @@ public class WiktionarySource implements DictionaryDataSource {
 
                 if (response.isSuccessful() && response.body() != null) {
 
-                    var pageEntry = response.body().getQuery().getPageNumber().firstEntry();
+                    var pageEntry = response.body().getQuery().getPageNumber().entrySet().iterator().next();
                     if (pageEntry == null) {
                         callback.onDataNotAvailable();
                         return;

--- a/app/src/main/java/com/guillermonegrete/tts/db/Words.java
+++ b/app/src/main/java/com/guillermonegrete/tts/db/Words.java
@@ -3,9 +3,6 @@ package com.guillermonegrete.tts.db;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.SerializedName;
-
 import androidx.annotation.Nullable;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
@@ -26,14 +23,10 @@ public class Words implements Parcelable {
 
     @ColumnInfo(name = "lang")
     @NonNull
-    @SerializedName("detectedLanguage.language")
-    @Expose
     public String lang;
 
     @ColumnInfo(name = "definition")
     @NonNull
-    @SerializedName("translations.text")
-    @Expose
     public String definition;
 
     @Nullable
@@ -79,7 +72,7 @@ public class Words implements Parcelable {
         notes = in.readString();
     }
 
-    public static final Creator<Words> CREATOR = new Creator<Words>() {
+    public static final Creator<Words> CREATOR = new Creator<>() {
         @Override
         public Words createFromParcel(Parcel in) {
             return new Words(in);

--- a/app/src/main/java/com/guillermonegrete/tts/di/ApplicationModule.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/di/ApplicationModule.kt
@@ -133,7 +133,7 @@ object ApplicationModule {
 
     @Singleton
     @Provides
-    fun provideWiktionarySource(): DictionaryDataSource = WiktionarySource()
+    fun provideWiktionarySource(client: OkHttpClient): DictionaryDataSource = WiktionarySource(client)
 
     @Provides
     fun provideTextDetectorSource(

--- a/app/src/main/java/com/guillermonegrete/tts/di/ApplicationModule.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/di/ApplicationModule.kt
@@ -129,11 +129,11 @@ object ApplicationModule {
 
     @Singleton
     @Provides
-    fun provideExternalLinksSource(app: Application): ExternalLinksDataSource = AssetsExternalLinksSource(app)
+    fun provideExternalLinksSource(app: Application, moshi: Moshi): ExternalLinksDataSource = AssetsExternalLinksSource(app, moshi)
 
     @Singleton
     @Provides
-    fun provideWiktionarySource(client: OkHttpClient): DictionaryDataSource = WiktionarySource(client)
+    fun provideWiktionarySource(client: OkHttpClient, moshi: Moshi): DictionaryDataSource = WiktionarySource(client, moshi)
 
     @Provides
     fun provideTextDetectorSource(
@@ -176,7 +176,7 @@ object ApplicationModule {
     fun provideRetrofit(client: OkHttpClient, baseUrl: String, moshi: Moshi): Retrofit = Retrofit.Builder()
         .baseUrl(baseUrl)
         .client(client)
-        .addConverterFactory(MoshiConverterFactory.create(moshi).asLenient())
+        .addConverterFactory(MoshiConverterFactory.create(moshi))
         .build()
 
     @Singleton

--- a/app/src/test/java/com/guillermonegrete/tts/data/source/remote/WiktionaryRequestTest.java
+++ b/app/src/test/java/com/guillermonegrete/tts/data/source/remote/WiktionaryRequestTest.java
@@ -1,0 +1,63 @@
+package com.guillermonegrete.tts.data.source.remote;
+
+
+import com.guillermonegrete.tts.textprocessing.domain.model.WikiItem;
+import com.guillermonegrete.tts.textprocessing.domain.model.WiktionaryItem;
+import com.guillermonegrete.tts.textprocessing.domain.model.WiktionaryLangHeader;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import java.util.List;
+
+public class WiktionaryRequestTest {
+
+    @Test
+    public void splitRequestByLanguage(){
+
+        String input = "\n== English ==\n\n\n=== Etymology ===\nBorrowed from Spanish hola.\n\n\n=== Anagrams ===\nHALO, halo, halo-\n\n" +
+                "\n== Asturian ==\n\n\n=== Pronunciation ===\nIPA(key): /\u02c8o.la/\n\n\n=== Interjection ===\nhola\n\nhello, hi\n\n" +
+                "\n== Catalan ==\n\n\n=== Etymology ===\nFrom Spanish hola\n\n(Valencian) IPA(key): /\u02c8o.la/\n\n\n=== Interjection ===\nhola\n\nhello, hi\n\n" +
+                "\n== Dutch ==\n\n\n=== Pronunciation ===\n\n\n=== Interjection ===\nhola\n\nhallo, hoi\n\n\n=== Anagrams ===\nhalo\n\n" +
+                "\n== Esperanto ==\n\n\n=== Pronunciation ===\nIPA(key): /\u02c8ho.la/\n\n\n=== Interjection ===\nhola\n\nhey, oi.\n\n" +
+                "\n== French ==\n\n\n=== Pronunciation ===\n(aspirated h) IPA(key): /\u0254\n\n\n=== Anagrams ===\nhalo\n\n" +
+                "\n== Icelandic ==\n\n\n=== Pronunciation ===\nIPA(key): /\u02c8h\u0254\u02d0la/\nRhymes: -\u0254\u02d0la\n\n" +
+                "\n== Ido ==\n\n\n=== Etymology ===\nFrom Spanish hola.\n\n\n=== Pronunciation ===\nIPA(key): /\u02c8ho.la/\n\n" +
+                "\n== Irish ==\n\n\n=== Pronunciation ===\nIPA(key): [\u02c8h\u0254l\u032a\u02e0\u0259]\n\n\n=== Noun ===\nhola m\n\nh-prothesized form of ola\n\n" +
+                "\n== Norwegian Bokm\u00e5l ==\n\n\n=== Alternative forms ===\nholen\n\n\n=== Noun ===\nhola m, f\n\ndefinite feminine singular of hole\n\n" +
+                "\n== Norwegian Nynorsk ==\n\n\n=== Noun ===\nhola f\n\ndefinite singular of hole\n\n" +
+                "\n== Spanish ==\n\n\n=== Etymology ===\n\nUnknown. Hola is etymologically unrelated to the Germanic expressions hello in English and hallo in German";
+        List<String> result = WiktionarySource.WiktionaryParser.getLanguages(input);
+        int expectedSize = 12;
+        assertEquals(expectedSize, result.size());
+    }
+
+    @Test
+    public void parser_generates_one_of_each_type(){
+        String input = "\n== English ==\n\n\n=== Etymology ===\nBorrowed from Spanish hola.";
+        List<WikiItem> result_items = WiktionarySource.WiktionaryParser.parse(input);
+
+        assertEquals(1, getItemTypeOccurrences(result_items, WiktionaryItem.class));
+        assertEquals(1, getItemTypeOccurrences(result_items, WiktionaryLangHeader.class));
+    }
+
+    @Test
+    public void parses_two_languages(){
+        String input = "\n== English ==\n\n\n=== Etymology ===\nBorrowed from Spanish hola.\n== Spanish ==\n\n\n=== Etymology ===\nBorrowed from Spanish hola.";
+        List<WikiItem> result_items = WiktionarySource.WiktionaryParser.parse(input);
+
+        assertEquals(2, getItemTypeOccurrences(result_items, WiktionaryItem.class));
+        assertEquals(2, getItemTypeOccurrences(result_items, WiktionaryLangHeader.class));
+    }
+
+    private int getItemTypeOccurrences(List<WikiItem> items, Class type){
+
+        int count = 0;
+        for (WikiItem item : items){
+            if(item.getClass() ==  type){
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/app/src/test/java/com/guillermonegrete/tts/data/source/remote/WiktionaryTest.java
+++ b/app/src/test/java/com/guillermonegrete/tts/data/source/remote/WiktionaryTest.java
@@ -1,0 +1,68 @@
+package com.guillermonegrete.tts.data.source.remote;
+
+import com.guillermonegrete.tts.textprocessing.domain.model.WikiItem;
+import com.guillermonegrete.tts.textprocessing.domain.model.WiktionaryItem;
+import com.guillermonegrete.tts.textprocessing.domain.model.WiktionaryLangHeader;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class WiktionaryTest {
+
+
+    @Test
+    public void process_sub_header_without_body_text(){
+        // Extract from: https://en.wiktionary.org/w/api.php?action=query&prop=extracts&format=json&explaintext=&redirects=1&titles=castell
+        String wikiExtract = "\n== Welsh ==\n\n\n=== Etymology ===\nBorrowed from Latin castellum.\n\n\n=== Pronunciation ===\n(North Wales) (standard) (colloquial) IPA(key): /ˈkasdɛɬ/, [ˈkʰastɛɬ]\n\n\n=== Noun ===\ncastell m (plural cestyll or castelli)\n\ncastle (fortified building)\nrook (chess piece)\n\n\n==== Synonyms ====\ncaer\n\n\n=== Mutation ===";
+
+        List<WikiItem> resultItems = WiktionarySource.WiktionaryParser.parse(wikiExtract);
+
+        List<WikiItem> expectedItems = Arrays.asList(
+                new WiktionaryLangHeader("Welsh"),
+                new WiktionaryItem("Borrowed from Latin castellum.\n\n", "Etymology"),
+                new WiktionaryItem("(North Wales) (standard) (colloquial) IPA(key): /ˈkasdɛɬ/, [ˈkʰastɛɬ]\n\n", "Pronunciation"),
+                new WiktionaryItem("castell m (plural cestyll or castelli)\n\ncastle (fortified building)\nrook (chess piece)\n\n\n Synonyms \ncaer\n\n", "Noun"),
+                new WiktionaryItem("", "Mutation ")
+        );
+
+        assertWikiItemList(expectedItems, resultItems);
+    }
+
+    @Test
+    public void process_sub_header_with_five_equals(){
+        String wikiExtract = "\n== German ==\n\n\n=== Pronunciation ===\nDescription 1\n\n\n==== Adverb ====\nDescription 2\n\n\n===== Synonyms =====\nDescription 3\n\n\n";
+        List<WikiItem> resultItems = WiktionarySource.WiktionaryParser.parse(wikiExtract);
+
+        List<WikiItem> expectedItems = Arrays.asList(
+                new WiktionaryLangHeader("German"),
+                new WiktionaryItem("Description 1\n\n\n Adverb \nDescription 2\n\n\n Synonyms \nDescription 3\n\n\n", "Pronunciation")
+        );
+
+        assertWikiItemList(expectedItems, resultItems);
+    }
+
+    private void assertWikiItemList(List<WikiItem> expected, List<WikiItem> actual){
+        assertEquals(expected.size(), actual.size());
+
+        for(int i=0; i<expected.size(); i++){
+            assertWikiItem(expected.get(i), actual.get(i));
+        }
+    }
+
+    private void assertWikiItem(WikiItem expected, WikiItem actual){
+        assertEquals(expected.getClass(), actual.getClass());
+
+        if(expected instanceof WiktionaryLangHeader expectedHeader){
+            WiktionaryLangHeader actualHeader = (WiktionaryLangHeader) actual;
+            assertEquals(expectedHeader.getLanguage(), actualHeader.getLanguage());
+        }else if(expected instanceof WiktionaryItem expectedHeader){
+            WiktionaryItem actualHeader = (WiktionaryItem) actual;
+            assertEquals(expectedHeader.getItemText(), actualHeader.getItemText());
+            assertEquals(expectedHeader.getSubHeaderText(), actualHeader.getSubHeaderText());
+        }
+    }
+}


### PR DESCRIPTION
Closes #261.

Restored the call to the old API because it works again and it already worked with a `RecyclerView` which provides better performance than a single `TextView`.
Also removed Gson, the project now only uses Moshi for JSON serialization.

In case the old API stops working again, the XML endpoint can be used by removing `explaintext=` from the URL. The way to parse this endpoint is:

- The `<h2>` tags are headers
- The `<h3>` tags are subheaders
- The text between the end of the `<h3>` tag and the next `<h2>` or `<h3>` tag is the item text.