### PR TITLE
Fixed incorrect sentence position and crash when selecting the last sentence.

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/data/source/remote/GooglePublicSource.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/data/source/remote/GooglePublicSource.kt
@@ -37,21 +37,7 @@ class GooglePublicSource @Inject constructor(private val googlePublicAPI: Google
      * The translate API removes the space between the sentences which leads to mismatches with the input text, so it has to be re added
      */
     private fun toTranslation(response: GoogleTranslateResponse): Translation{
-        val sentences = response.sentences
-        val segments = mutableListOf<Segment>()
-
-        for(i in 0 until sentences.size - 1){
-            val sentence = sentences[i]
-            // If the original line ended with a new line the translate API doesn't change it
-            // Then it's not necessary to add a white space
-            val space = if(sentence.orig.endsWith("\n")) "" else " "
-            val segment = Segment(sentence.trans, sentence.orig + space)
-            segments.add(segment)
-        }
-
-        // The final line is unaffected by the api, so don't modify it.
-        segments.add(Segment(sentences.last().trans, sentences.last().orig))
-
+        val segments = response.sentences.map { Segment(it.trans, it.orig) }
         val language = if(response.src == "iw") "he" else response.src
         return Translation(segments, language)
     }

--- a/app/src/test/java/com/guillermonegrete/tts/data/source/remote/GooglePublicSourceTest.kt
+++ b/app/src/test/java/com/guillermonegrete/tts/data/source/remote/GooglePublicSourceTest.kt
@@ -55,7 +55,7 @@ class GooglePublicSourceTest {
         val selectedText = "La primer oración del texto. Y la segunda oración del texto.\nY la tercer oración."
         val response = GoogleTranslateResponse(
             listOf(
-                Sentence( "The first sentence of the text. ", "La primer oración del texto."),
+                Sentence( "The first sentence of the text.", "La primer oración del texto."),
                 Sentence( "And the second sentence of the text.\n", "Y la segunda oración del texto.\n"),
                 Sentence( "And the third sentence.", "Y la tercer oración."),
             ), "es")
@@ -64,9 +64,9 @@ class GooglePublicSourceTest {
         val result = dataSource.getTranslation(selectedText, "es", "en")
         val expectedTranslation = Translation(
             listOf(
-                Segment("The first sentence of the text. ", "La primer oración del texto. "),
-                Segment( "And the second sentence of the text.\n", "Y la segunda oración del texto.\n"),
-                Segment( "And the third sentence.", "Y la tercer oración."),
+                Segment("The first sentence of the text.", "La primer oración del texto."),
+                Segment("And the second sentence of the text.\n", "Y la segunda oración del texto.\n"),
+                Segment("And the third sentence.", "Y la tercer oración."),
             ), "es")
 
         assertEquals(expectedTranslation, result)


### PR DESCRIPTION
This was because the API used to remove spaces so those were added, because the space is not removed anymore this caused the offset.