### PR TITLE
Bugfix/#302 older device text selection

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/webreader/ParagraphAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/ParagraphAdapter.kt
@@ -1,6 +1,7 @@
 package com.guillermonegrete.tts.webreader
 
 import android.annotation.SuppressLint
+import android.os.Build
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.BackgroundColorSpan
@@ -44,6 +45,7 @@ import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 import androidx.core.graphics.toColorInt
+import androidx.core.view.iterator
 import com.guillermonegrete.tts.utils.count
 
 class ParagraphAdapter(
@@ -598,6 +600,7 @@ class ParagraphAdapter(
 
             var item: ParagraphItem? = null
             override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+                mode?.title = null
                 unselectSentence()
                 highlightedTextView = binding.paragraph
                 highlightedTextPos = adapterPosition
@@ -613,9 +616,16 @@ class ParagraphAdapter(
 
                 menu.clear()
                 menu.add(Menu.NONE, android.R.id.copy, Menu.NONE, android.R.string.copy)
-                menu.add(Menu.NONE, TRANSLATE_MENU_ITEM_ID, Menu.NONE, R.string.translate_description)
                 val inflater = mode?.menuInflater
                 inflater?.inflate(R.menu.menu_context_web_reader, menu)
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                    /**
+                     * For sdk < 23. the context menu is in the action bar.
+                     * The overflow menu doesn't work with selected text, when shown the popup menu grabs focus and unselects the text finishing the action mode.
+                     * Force all items to show in the action bar to avoid the overflow menu.
+                     */
+                    for (item in menu.iterator()) item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+                }
 
                 val selStart = binding.paragraph.selectionStart
                 val selEnd = binding.paragraph.selectionEnd
@@ -669,7 +679,7 @@ class ParagraphAdapter(
                         mode?.finish()
                         true
                     }
-                    TRANSLATE_MENU_ITEM_ID -> {
+                    R.id.translate_action -> {
                         val text = getHighlightedText() ?: return false
                         onTranslateHighlightedText(text.toString(), span)
                         mode?.finish()
@@ -1181,8 +1191,6 @@ class ParagraphAdapter(
     }
 
     companion object {
-        private const val TRANSLATE_MENU_ITEM_ID = 3
-
         private const val SWIPE_THRESHOLD = 0.8
         private const val SWIPE_VELOCITY_THRESHOLD = 0.8
     }

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/ParagraphAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/ParagraphAdapter.kt
@@ -59,7 +59,8 @@ class ParagraphAdapter(
     val scanParagraph: (dbWords: List<Words>, text: String, position: Int) -> List<WordState> = { _, _, _ -> emptyList() },
 ): RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
-    private var items = emptyList<ParagraphItem>()
+    var items = emptyList<ParagraphItem>()
+        private set
     var isPageSaved: Boolean = false
 
     private var expandedItem: SelectedParagraph? = null

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -184,6 +184,32 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                     }
 
                     launch {
+                        viewModel.notes.collect {
+                            val dbNotes = it.toMutableList()
+
+                            var index = 0
+                            val notes = adapter.items.mapIndexed { i, it ->
+                                val nextIndex = index + it.original.length
+                                // Search the notes applied to this paragraph
+                                val paragraphNotes = dbNotes.filter { dbNote ->
+                                    dbNote.position in index until nextIndex
+                                }
+
+                                val noteItems = paragraphNotes.map { note ->
+                                    val itemStart = note.position - index
+                                    NoteItem(note.text, Span(itemStart, itemStart + note.length), note.color.toColorInt(), note.id)
+                                }
+
+                                index = nextIndex
+                                dbNotes.removeAll(paragraphNotes)
+                                noteItems
+                            }
+
+                            adapter.updateNotes(notes, getVisibleListItems())
+                        }
+                    }
+
+                    launch {
                         viewModel.updatedNote.collect { result ->
                             when(result){
                                 is ModifiedNote.Update -> {
@@ -313,7 +339,7 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
     private fun setParagraphList(page: PageInfo, iconsVisible: MutableState<Boolean>) {
         pageText = page.text
 
-        with(binding){
+        with(binding) {
             paragraphsList.isVisible = true
 
             // Split text and parse from html
@@ -339,34 +365,6 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
             iconsVisible.value = true
             setAdapterListeners()
 
-            lifecycleScope.launch {
-                repeatOnLifecycle(Lifecycle.State.STARTED) {
-
-                    viewModel.notes.collect {
-                        val dbNotes = it.toMutableList()
-
-                        index = 0
-                        val notes = splitParagraphs.mapIndexed { i, it ->
-                            val nextIndex = index + it.paragraph.length
-                            // Search the notes applied to this paragraph
-                            val paragraphNotes = dbNotes.filter { dbNote ->
-                                dbNote.position in index until nextIndex
-                            }
-
-                            val noteItems = paragraphNotes.map { note ->
-                                val itemStart = note.position - index
-                                NoteItem(note.text, Span(itemStart, itemStart + note.length), note.color.toColorInt(), note.id)
-                            }
-
-                            index = nextIndex
-                            dbNotes.removeAll(paragraphNotes)
-                            noteItems
-                        }
-
-                        adapter.updateNotes(notes, getVisibleListItems())
-                    }
-                }
-            }
             viewModel.getNotes()
         }
     }

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -1,6 +1,7 @@
 package com.guillermonegrete.tts.webreader
 
 import android.annotation.SuppressLint
+import android.os.Build
 import android.os.Bundle
 import android.text.method.ScrollingMovementMethod
 import android.view.*
@@ -260,12 +261,23 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
         val initialBarSize = appBarSize
         ViewCompat.setOnApplyWindowInsetsListener(binding.paragraphsList) { v, windowInsets ->
             val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
-            v.updatePadding(top = insets.top)
             binding.composeBar.updatePadding(bottom = insets.bottom)
             binding.composeRoot.updatePadding(top = insets.top)
             appBarSize = initialBarSize + insets.bottom
-            updateListBottomPadding(0)
+            handleListPadding(insets.top, appBarSize)
             WindowInsetsCompat.CONSUMED
+        }
+    }
+
+    private fun handleListPadding(top: Int, bottom: Int) {
+        val v = binding.paragraphsList
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            v.updatePadding(top = top, bottom = bottom)
+        } else {
+            // Avoid unnecessarily updating padding because in older version it cancels the action mode (e.g. text selection).
+            if (v.paddingTop != top && v.paddingTop != bottom) {
+                v.updatePadding(top = top, bottom = bottom)
+            }
         }
     }
 

--- a/app/src/main/res/layout/fragment_web_reader.xml
+++ b/app/src/main/res/layout/fragment_web_reader.xml
@@ -23,6 +23,7 @@
             android:layout_height="match_parent"
             android:paddingBottom="@dimen/web_reader_bar_height"
             android:clipToPadding="false"
+            android:contentDescription="@string/paragraphs_list"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listitem="@layout/paragraph_item"/>
 

--- a/app/src/main/res/menu/menu_context_web_reader.xml
+++ b/app/src/main/res/menu/menu_context_web_reader.xml
@@ -3,6 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/translate_action"
+        android:title="@string/translate_description"
+        android:icon="@drawable/ic_translate_black_24dp"
+        app:showAsAction="ifRoom" />
+
+    <item
         android:id="@+id/add_new_note_action"
         android:title="@string/new_note"
         android:icon="@drawable/baseline_note_add_24"
@@ -11,6 +17,7 @@
     <item
         android:id="@+id/add_saved_word_action"
         android:title="@string/save_icon_description"
-        app:showAsAction="always" />
+        android:icon="@drawable/ic_add_black_24dp"
+        app:showAsAction="ifRoom" />
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -234,6 +234,7 @@
     <string name="pick_language_web_reader">To see more information about this text, please pick a language using the bottom bar</string>
     <string name="create_db_item_dialog_title">Create new:</string>
     <string name="web_reader_words_action">Show saved words</string>
+    <string name="paragraphs_list">Paragraphs list</string>
 
     <!-- Text/Epub visualizer-->
     <string name="white_theme">White theme</string>


### PR DESCRIPTION
Closes #302.

All the menu items must appear in the action bar because the overflow menu doesn't work with selected text (when the menu opens the text gets deselected).

Also, fixed a crash when switching to the web version of the page. This was caused due to a race condition when adding the initial notes. The race condition was caused by multiple flows trying to load the notes, this was fixed by preventing the creation of more than one flow.