### PR TITLE
Fixed saved words for items after the initial range not loading.

### DIFF
--- a/app/src/main/java/com/guillermonegrete/tts/webreader/ParagraphAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/ParagraphAdapter.kt
@@ -73,6 +73,11 @@ class ParagraphAdapter(
     var initialWordsLoaded = false
 
     /**
+     * This is the range of the initial visible items. Used for the inital load of saved words.
+     */
+    var initialRange: IntRange? = null
+
+    /**
      * Whether the current selected text (started with a long-press) is overlapping a note.
      */
     var isOverlappingNotes = false
@@ -278,8 +283,10 @@ class ParagraphAdapter(
 
             addSavedWords(item, spannable)
 
-            if (initialWordsLoaded && !item.databaseWordsLoaded) {
-                loadDatabaseWord(item.original, adapterPosition)
+            val pos = adapterPosition
+            if ((initialWordsLoaded || initialRange?.contains(pos) == false) // Load words if this item doesn't belong to the initial range (those are already loading/loaded)
+                && !item.databaseWordsLoaded) {
+                loadDatabaseWord(item.original, pos)
             }
 
             binding.paragraph.setText(spannable, TextView.BufferType.SPANNABLE)

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderFragment.kt
@@ -166,7 +166,6 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
                     launch {
                         viewModel.pageSavedWords.collect { result ->
                             adapter.updateSavedWords(result.words, result.start)
-                            adapter.initialWordsLoaded = true
                         }
                     }
 
@@ -850,8 +849,11 @@ class WebReaderFragment : Fragment(R.layout.fragment_web_reader){
 
     private fun loadWordsForVisibleItems() {
         val range = getVisibleListItems()
+        adapter.initialRange = range
         val text = adapter.getItemsText(range)
-        viewModel.loadLocalWords(text, range.first)
+        viewModel.loadLocalWords(text, range.first) {
+            adapter.initialWordsLoaded = true
+        }
     }
 
     private fun hideSavedWords() {

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderViewModel.kt
@@ -661,7 +661,11 @@ class WebReaderViewModel @AssistedInject constructor(
         }
     }
 
-    fun loadLocalWords(texts: List<String>, index: Int) {
+    fun loadLocalWords(
+        texts: List<String>,
+        index: Int,
+        onFinished: () -> Unit = {}
+    ) {
         if (!showWords) return
 
         viewModelScope.launch {
@@ -672,6 +676,7 @@ class WebReaderViewModel @AssistedInject constructor(
                     viewModelScope.launch {
                         val paragraphWords = withContext(defaultDispatcher) { findWordsInSections(words, sections, index) }
                         _pageSavedWords.emit(SavedWordsSection(paragraphWords, index))
+                        onFinished()
                     }
                 }
 


### PR DESCRIPTION
This issue was caused because sometimes those items were bound before the initial load was completed and all items weren't allowed to load the saved words before the initial was complete. This was fixed by allowing items outside the initial range to load the words.