### PR TITLE
Bugfix/#307 composables accessibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     implementation "androidx.datastore:datastore-preferences:1.0.0"
 
     // Compose
-    def composeBom = platform('androidx.compose:compose-bom:2025.04.01')
+    def composeBom = platform('androidx.compose:compose-bom:2025.05.01')
     implementation composeBom
     androidTestImplementation composeBom
 

--- a/app/src/main/java/com/guillermonegrete/tts/common/compose/Composables.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/common/compose/Composables.kt
@@ -159,6 +159,7 @@ fun ExternalLinksDialog(
     isShown: Boolean,
     links: ExternalLinkList,
     selection: Int,
+    modifier: Modifier = Modifier,
     onItemClick: (Int) -> Unit = {},
     onDismiss: () -> Unit = {},
 ) {
@@ -175,8 +176,7 @@ fun ExternalLinksDialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
-        Surface(modifier = Modifier
-            .padding(horizontal = 16.dp)
+        Surface(modifier = modifier
             .clip(RoundedCornerShape(12.dp))
         ) {
             Column(Modifier.height(400.dp)) {
@@ -277,7 +277,7 @@ const val CONFIRM_BTN_TAG = "confirm_btn"
 @Composable
 fun ExternalLinksDialogPreview() {
     AppTheme {
-        val links = ExternalLinkList(List(4) { ExternalLinkUI("External site", "", "") })
+        val links = ExternalLinkList(List(4) { ExternalLinkUI("External site ${it + 1}", "", "") })
         ExternalLinksDialog(true, links, 1)
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/common/compose/Composables.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/common/compose/Composables.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -44,7 +45,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
@@ -108,10 +111,13 @@ fun Spinner(
         Button(
             onClick = { expanded = !expanded },
             contentPadding = PaddingValues(8.dp, end = 0.dp),
+            modifier = Modifier.widthIn(0.dp, 320.dp) // Max recommended width for buttons
         ) {
             Text(
                 text = displayText ?: list.items.getOrNull(selected) ?: "",
-                modifier = Modifier.testTag(SPINNER_TEXT_TAG),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
+                modifier = Modifier.weight(1f, fill = false).testTag(SPINNER_TEXT_TAG),
             )
             Icon(
                 imageVector = Icons.Filled.ArrowDropDown,
@@ -283,7 +289,9 @@ fun SpinnerPreview() {
     AppTheme {
         Column {
             Spinner(suggestions)
-            Spinner(suggestions, 0)
+            Spinner(suggestions, preselected =  1)
+            val longText = LoremIpsum(words = 10).values.toList().first()
+            Spinner(StringList(listOf(longText)), preselected = 0)
         }
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/common/compose/Composables.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/common/compose/Composables.kt
@@ -100,6 +100,7 @@ fun YesNoDialogPreview() {
 @Composable
 fun Spinner(
     list: StringList,
+    modifier: Modifier = Modifier,
     preselected: Int = -1,
     displayText: String? = null,
     onItemSelected: (Int, String) -> Unit = { _, _ -> }
@@ -107,7 +108,7 @@ fun Spinner(
     var selected by remember(preselected) { mutableIntStateOf(preselected) }
     var expanded by remember { mutableStateOf(false) }
 
-    Box {
+    Box(modifier) {
         Button(
             onClick = { expanded = !expanded },
             contentPadding = PaddingValues(8.dp, end = 0.dp),

--- a/app/src/main/java/com/guillermonegrete/tts/common/compose/ComposeExt.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/common/compose/ComposeExt.kt
@@ -1,0 +1,13 @@
+package com.guillermonegrete.tts.common.compose
+
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.runtime.Composable
+import androidx.window.core.layout.WindowHeightSizeClass
+import androidx.window.core.layout.WindowWidthSizeClass
+
+@Composable
+fun isDesktopOrTabletSize(): Boolean {
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    return windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.EXPANDED
+            && (windowSizeClass.windowHeightSizeClass == WindowHeightSizeClass.EXPANDED || windowSizeClass.windowHeightSizeClass == WindowHeightSizeClass.MEDIUM)
+}

--- a/app/src/main/java/com/guillermonegrete/tts/common/notes/NotesListScreen.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/common/notes/NotesListScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.filled.Delete
@@ -23,10 +23,14 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -43,6 +47,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -53,6 +58,7 @@ import com.guillermonegrete.tts.common.compose.YesNoDialog
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NotesListScreen(
     notes: List<NoteItem>,
@@ -63,10 +69,10 @@ fun NotesListScreen(
 
     Surface  {
         LazyColumn(contentPadding = WindowInsets.systemBars.asPaddingValues()) {
-            items(
+            itemsIndexed(
                 notes,
-                key = { it.id },
-            ) { note ->
+                key = { _, it -> it.id },
+            ) { index, note ->
                 Column(Modifier.fillMaxWidth())  {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Column (Modifier.padding(8.dp).weight(1f))  {
@@ -78,7 +84,7 @@ fun NotesListScreen(
                         ) {
                             Icon(
                                 imageVector = Icons.Default.MoreVert,
-                                contentDescription = "Options"
+                                contentDescription = "Options item $index"
                             )
                         }
                     }
@@ -95,10 +101,13 @@ fun NotesListScreen(
     }
 
     selectedNote?.let { note ->
-        NoteItemMenu(onDismiss = { selectedNote = null }) {
-            onMenuAction(it, note)
-            selectedNote = null
-        }
+        NoteItemMenu(
+            onDismiss = { selectedNote = null },
+            onItemClick =  {
+                onMenuAction(it, note)
+                selectedNote = null
+            }
+        )
     }
 }
 
@@ -142,9 +151,10 @@ fun NotesListScreen(
 @Composable
 fun NoteItemMenu(
     onDismiss: () -> Unit,
+    state: SheetState = rememberModalBottomSheetState(),
     onItemClick: (item: NoteMenuItem) -> Unit = {},
 ) {
-    ModalBottomSheet(onDismiss) {
+    ModalBottomSheet(onDismiss, sheetState =  state) {
         Column(modifier = Modifier.padding(horizontal = 8.dp)) {
             val goToDesc = stringResource(R.string.go_to_text)
             DropdownMenuItem(
@@ -186,21 +196,25 @@ fun SnackBarError(viewModel: NotesListViewModel) {
     }
 }
 
-@Preview
+@PreviewScreenSizes
 @Composable
 fun NotesListScreenPreview() {
     NotesListScreen(dummyNotes)
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
 fun NoteItemMenuPreview() {
-    NoteItemMenu ({}) {  }
+    val state = rememberStandardBottomSheetState(
+        initialValue = SheetValue.Expanded
+    )
+    NoteItemMenu ({}, state) {  }
 }
 
 val dummyNotes = listOf(
     NoteItem(0, "Dummy text", "Dummy note text", 0xFF0000FF.toInt(), 10),
-    NoteItem(1, "Another dummy text", "More dummy note text, a text so ridiculously long that there it requires multiple rows", 0xFF00FF00.toInt(), 15),
+    NoteItem(1, "Another dummy text that is long enough to take 2 lines", "More dummy note text, a text so ridiculously long that there it requires multiple rows", 0xFF00FF00.toInt(), 15),
 )
 
 const val DELETE_NOTE_BTN_TAG = "delete_note_btn"

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/tabs/EnterTextFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/tabs/EnterTextFragment.kt
@@ -16,11 +16,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
@@ -37,12 +39,16 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
 import androidx.fragment.compose.content
 import androidx.window.core.layout.WindowHeightSizeClass
 import com.guillermonegrete.tts.R
+import com.guillermonegrete.tts.common.compose.isDesktopOrTabletSize
 import com.guillermonegrete.tts.importtext.visualize.VisualizeTextActivity
 import com.guillermonegrete.tts.importtext.visualize.VisualizeTextFragment
 import com.guillermonegrete.tts.ui.theme.AppTheme
@@ -70,13 +76,12 @@ class EnterTextFragment: Fragment() {
         startActivity(intent)
     }
 
-    @PreviewScreenSizes
     @Composable
-    fun EnterTextScreen() {
+    fun EnterTextScreen(text: String = "") {
         AppTheme {
             val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
             var textField by rememberSaveable(stateSaver = TextFieldValue.Saver) {
-                mutableStateOf(TextFieldValue())
+                mutableStateOf(TextFieldValue(text))
             }
             if (windowSizeClass.windowHeightSizeClass == WindowHeightSizeClass.COMPACT) {
                 EnterTextScreenHeightCompact( { textField }, { textField = it } )
@@ -175,15 +180,21 @@ class EnterTextFragment: Fragment() {
         val field = textField()
         var textFieldValue by remember(field) { mutableStateOf(field) }
         val clearVisible by remember(textFieldValue.text) { derivedStateOf { textFieldValue.text.isNotBlank() } }
+        val useLargeText = isDesktopOrTabletSize()
+        val style = if (useLargeText) LocalTextStyle.current.copy(fontSize = 20.sp) else LocalTextStyle.current
         OutlinedTextField(
             value = textFieldValue,
             onValueChange = onTextFieldChange,
             label = { Text(stringResource(R.string.import_text_hint)) },
             minLines = textLines,
             maxLines = textLines,
+            textStyle = style,
             trailingIcon = {
                 if (clearVisible) {
-                    IconButton(onClick = { onTextFieldChange(TextFieldValue()) }) {
+                    IconButton(
+                        onClick = { onTextFieldChange(TextFieldValue()) },
+                        modifier = Modifier.padding(8.dp),
+                    ) {
                         Icon(
                             imageVector = Icons.Default.Clear,
                             contentDescription = "Clear"
@@ -191,8 +202,16 @@ class EnterTextFragment: Fragment() {
                     }
                 }
             },
-            modifier = Modifier.testTag(ENTER_TEXT_TAG)
+            modifier = Modifier.widthIn(0.dp, 488.dp).testTag(ENTER_TEXT_TAG)
         )
+    }
+
+    @PreviewScreenSizes
+    @Composable
+    fun EnterTextScreenPreview(@PreviewParameter(LoremIpsum::class) longText: String ) {
+        AppTheme {
+            EnterTextScreen(longText)
+        }
     }
 }
 

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextFragment.kt
@@ -23,12 +23,15 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
 import androidx.annotation.StyleRes
 import androidx.appcompat.app.AlertDialog
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.IntentCompat
 import androidx.core.content.edit
@@ -1131,6 +1134,7 @@ class VisualizeTextFragment: Fragment(R.layout.fragment_visualize_text), DialogI
             selection = selectedLinkPos.intValue,
             onItemClick = viewModel::setWordLink,
             onDismiss = viewModel::hideWordLinks,
+            modifier = Modifier.padding(horizontal = 16.dp),
         )
 
         var addNoteVisible by remember { addNoteDialogVisible }

--- a/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextScreen.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/importtext/visualize/VisualizeTextScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -163,35 +164,33 @@ fun ContentMenu(
     onDismiss: () -> Unit,
     onItemClick: (item: ContentMenuItem) -> Unit = {},
 ) {
-    Box(
-        Modifier
-            .padding(WindowInsets.systemBars.asPaddingValues())
-            .padding(end = 8.dp) // Adds additional padding
+    Popup(
+        alignment = Alignment.BottomEnd,
+        onDismissRequest = onDismiss,
     ) {
-        Popup(
-            alignment = Alignment.BottomEnd,
-            onDismissRequest = onDismiss,
+        ElevatedCard(
+            Modifier
+                .padding(WindowInsets.systemBars.asPaddingValues())
+                .padding(end = 8.dp) // Adds additional padding
         ) {
-            ElevatedCard {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    if (hasToC) {
-                        Text(
-                            text = AnnotatedString(stringResource(R.string.table_of_contents)),
-                            modifier = Modifier
-                                .clickable(true) { onItemClick(ContentMenuItem.TABLE_OF_CONTENTS) }
-                                .testTag(TOC_BTN_TAG)
-                                .padding(8.dp),
-                        )
-                    }
-
+            Column(modifier = Modifier.padding(16.dp)) {
+                if (hasToC) {
                     Text(
-                        text = AnnotatedString(stringResource(R.string.show_notes_list)),
+                        text = AnnotatedString(stringResource(R.string.table_of_contents)),
                         modifier = Modifier
-                            .clickable(true) { onItemClick(ContentMenuItem.NOTES) }
-                            .testTag(NOTE_BTN_TAG)
+                            .clickable(true) { onItemClick(ContentMenuItem.TABLE_OF_CONTENTS) }
+                            .testTag(TOC_BTN_TAG)
                             .padding(8.dp),
                     )
                 }
+
+                Text(
+                    text = AnnotatedString(stringResource(R.string.show_notes_list)),
+                    modifier = Modifier
+                        .clickable(true) { onItemClick(ContentMenuItem.NOTES) }
+                        .testTag(NOTE_BTN_TAG)
+                        .padding(8.dp),
+                )
             }
         }
     }
@@ -201,15 +200,19 @@ fun ContentMenu(
 @Composable
 fun NoteSheetPreview() {
     AppTheme {
-        NoteSheet(true, {"My note text"})
+        Box(modifier = Modifier.fillMaxSize()) {
+            NoteSheet(true, { "My note text. ".repeat(15) })
+        }
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun ContentMenuPreview() {
     AppTheme {
-        ContentMenu(true, {})
+        Box(modifier = Modifier.fillMaxSize()) {
+            ContentMenu(true, {})
+        }
     }
 }
 

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
@@ -7,19 +7,21 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.content.SharedPreferences
 import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.InsetDrawable
 import android.os.Bundle
 import android.view.*
 import android.widget.*
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.core.os.BundleCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
@@ -67,6 +69,8 @@ import java.util.*
 import javax.inject.Inject
 import kotlin.math.abs
 import kotlin.math.sqrt
+import androidx.core.graphics.drawable.toDrawable
+import androidx.core.content.edit
 
 @AndroidEntryPoint
 class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
@@ -137,7 +141,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
         val dialog = super.onCreateDialog(savedInstanceState)
         window = dialog.window
         window?.requestFeature(Window.FEATURE_NO_TITLE)
-        val back = ColorDrawable(Color.TRANSPARENT)
+        val back = Color.TRANSPARENT.toDrawable()
         val margin = requireContext().dpToPixel(20)
         val inset = InsetDrawable(back, margin, 0, margin, 0)
         window?.setBackgroundDrawable(inset)
@@ -184,6 +188,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
                             onSourceLangChanged = { updateLanguageFrom(it) },
                             onTargetLangChanged = { updateLanguageTo(it) },
                             onDismiss = { dialog?.cancel() },
+                            modifier = Modifier.padding(16.dp),
                         )
 
                         Dialogs()
@@ -359,7 +364,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
     }
 
     private fun getLanguageFromPreference(): String {
-        // Give highest priority to the language set in the arguments, if null use the preference language
+        // Give the highest priority to the language set in the arguments, if null use the preference language
         val setLang = arguments?.getString(LANG_FROM_KEY)
         val preference = setLang ?: preferences.getString(SettingsFragment.PREF_LANGUAGE_FROM, "auto") ?: "auto"
         languageFromIndex = languagesISO.indexOf(preference)
@@ -600,8 +605,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
 
     override fun updateTranslation(translation: Translation) {
 
-        // If pager is not null, means we are using activity_processtext layout,
-        // otherwise is sentence layout
+        // If pager is not null, means we are using the word layout otherwise it's the sentence layout
         if (pager != null) {
             val detectLang = languageFrom == "auto"
             bindingWord.textLanguageCode.visibility = if (detectLang) View.VISIBLE else  View.GONE
@@ -686,7 +690,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
                     if(horizontalAxis){
                         params.x = iParamX + dRawX.toInt()
                     }else {
-                        // Multiple by 1 or -1 because the y axis can be inverted when using Gravity.Bottom param.
+                        // Multiply by 1 or -1 because the y-axis can be inverted when using Gravity.Bottom param.
                         params.y = iParamY + (dRawY * yAxis).toInt()
                         if(initialScreenY + dRawY.toInt() <= 0) return@setOnTouchListener false
                     }
@@ -797,7 +801,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
             android.R.layout.simple_spinner_dropdown_item
         )
         val item = adapter.getItem(languageFromIndex)
-        if (item != null) spinner.setText(item.toString(), false)
+        if (item != null) spinner.setText(item, false)
         spinner.setOnItemClickListener { _, _, position, _ -> updateLanguageFrom(position) }
         spinner.setOnClickListener { spinner.showDropDown() }
         spinner.post {
@@ -814,9 +818,9 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
         override fun onItemSelected(position: Int) {
             languageToISO = languagesISO[position]
             languagePreferenceIndex = position
-            val editor = preferences.edit()
-            editor.putInt(LANGUAGE_PREFERENCE, position)
-            editor.apply()
+            preferences.edit {
+                putInt(LANGUAGE_PREFERENCE, position)
+            }
             presenter.onLanguageSpinnerChange(languageFrom, languageToISO)
         }
     }
@@ -827,18 +831,18 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
             "auto"
         else
             languagesISO[position - 1]
-        val editor = preferences.edit()
-        editor.putString(SettingsFragment.PREF_LANGUAGE_FROM, languageFrom)
-        editor.apply()
+        preferences.edit {
+            putString(SettingsFragment.PREF_LANGUAGE_FROM, languageFrom)
+        }
         presenter.onLanguageSpinnerChange(languageFrom, languageToISO)
     }
 
     private fun updateLanguageTo(position: Int) {
         languagePreferenceIndex = position
         languageToISO = languagesISO[position]
-        val editor = preferences.edit()
-        editor.putInt(LANGUAGE_PREFERENCE, position)
-        editor.apply()
+        preferences.edit {
+            putInt(LANGUAGE_PREFERENCE, position)
+        }
         presenter.onLanguageSpinnerChange(languageFrom, languageToISO)
     }
 
@@ -849,7 +853,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
         }
     }
 
-    private inner class MyPageAdapter(fragment: Fragment) :
+    private class MyPageAdapter(fragment: Fragment) :
         FragmentStateAdapter(fragment) {
 
         val fragments = ArrayList<Fragment>()

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoDialog.kt
@@ -938,6 +938,7 @@ class TextInfoDialog: DialogFragment(), ProcessTextContract.View {
             selection = selectedLink.intValue,
             onItemClick = presenter::setWordLink,
             onDismiss = presenter::hideWordLinks,
+            modifier = Modifier.padding(horizontal = 16.dp),
         )
     }
 }

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoScreen.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoScreen.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
@@ -484,8 +485,10 @@ fun EditWordDialog(
                     keyboardActions = KeyboardActions(
                         onNext = { focusManager.moveFocus(FocusDirection.Down) }
                     ),
+                    singleLine = true,
                     modifier = Modifier
                         .widthIn(0.dp, 488.dp)
+                        .horizontalScroll(rememberScrollState())
                         .padding(bottom = 16.dp)
                 )
                 ExposedDropdownMenuBox(
@@ -504,6 +507,7 @@ fun EditWordDialog(
                         keyboardActions = KeyboardActions(
                             onNext = { focusManager.moveFocus(FocusDirection.Down) }
                         ),
+                        singleLine = true,
                         modifier = Modifier.menuAnchor(PrimaryNotEditable).widthIn(0.dp, 488.dp)
                     )
                     ExposedDropdownMenu(
@@ -531,7 +535,8 @@ fun EditWordDialog(
                     keyboardActions = KeyboardActions(
                         onNext = { focusManager.moveFocus(FocusDirection.Down) }
                     ),
-                    modifier = Modifier.widthIn(0.dp, 488.dp)
+                    singleLine = true,
+                    modifier = Modifier.widthIn(0.dp, 488.dp).horizontalScroll(rememberScrollState()),
                 )
 
                 TextField(
@@ -539,7 +544,7 @@ fun EditWordDialog(
                     onValueChange = { notesText = it },
                     label = { Text(stringResource(id = R.string.notes_edit_text)) },
                     singleLine = true,
-                    modifier = Modifier.widthIn(0.dp, 488.dp)
+                    modifier = Modifier.widthIn(0.dp, 488.dp).horizontalScroll(rememberScrollState()),
                 )
 
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier =  Modifier.padding(top = 8.dp))  {
@@ -660,7 +665,7 @@ fun EditWordDialogPreview() {
             "Hola",
             "es",
             "Hello",
-            "Spanish greeting",
+            "The most common and used spanish greeting",
             LanguagesList(listOf("English", "Spanish", "German"), listOf("en", "es", "de")),
             true
         )

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoScreen.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -23,6 +24,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
@@ -73,7 +75,6 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
@@ -143,11 +144,10 @@ fun SentenceDialog(
             tween(),
         )
 
-        Row {
-
-            // The spacers make sure the windows is filling the entire space, otherwise the dialog cuts off the swiping horizontally.
-            Spacer(modifier = Modifier.weight(1f))
-
+        Box(
+            modifier = Modifier.fillMaxWidth(), // prevents dialog from getting cut-off when swiping horizontally
+            contentAlignment = Alignment.Center,
+        ) {
             ElevatedCard(
                 modifier = modifier
                     .onSizeChanged {
@@ -205,8 +205,6 @@ fun SentenceDialog(
                     }
                 }
             }
-
-            Spacer(modifier = Modifier.weight(1f))
 
             // Handle swipeable events
             LaunchedEffect(swipeableState.settledValue) {
@@ -474,7 +472,10 @@ fun EditWordDialog(
 
     Dialog(onDismissRequest = onDismiss) {
         Surface(Modifier.testTag(EDIT_WORD_DIALOG_TAG)) {
-            Column(Modifier.padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+            Column(
+                Modifier.width(IntrinsicSize.Max).widthIn(0.dp, 520.dp).padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
                 val focusManager = LocalFocusManager.current
 
                 TextField(
@@ -487,14 +488,13 @@ fun EditWordDialog(
                     ),
                     singleLine = true,
                     modifier = Modifier
-                        .widthIn(0.dp, 488.dp)
-                        .horizontalScroll(rememberScrollState())
+                        .fillMaxWidth()
                         .padding(bottom = 16.dp)
                 )
                 ExposedDropdownMenuBox(
                     expanded = expanded,
                     onExpandedChange = { expanded = !expanded },
-                    modifier = Modifier.widthIn(0.dp, 488.dp)
+                    modifier = Modifier.fillMaxWidth()
                 ) {
                     val lang = languages.fullNames.getOrNull(indexLang) ?: ""
                     TextField(
@@ -508,7 +508,7 @@ fun EditWordDialog(
                             onNext = { focusManager.moveFocus(FocusDirection.Down) }
                         ),
                         singleLine = true,
-                        modifier = Modifier.menuAnchor(PrimaryNotEditable).widthIn(0.dp, 488.dp)
+                        modifier = Modifier.menuAnchor(PrimaryNotEditable).fillMaxWidth(),
                     )
                     ExposedDropdownMenu(
                         expanded = expanded,
@@ -536,7 +536,7 @@ fun EditWordDialog(
                         onNext = { focusManager.moveFocus(FocusDirection.Down) }
                     ),
                     singleLine = true,
-                    modifier = Modifier.widthIn(0.dp, 488.dp).horizontalScroll(rememberScrollState()),
+                    modifier = Modifier.fillMaxWidth(),
                 )
 
                 TextField(
@@ -544,7 +544,7 @@ fun EditWordDialog(
                     onValueChange = { notesText = it },
                     label = { Text(stringResource(id = R.string.notes_edit_text)) },
                     singleLine = true,
-                    modifier = Modifier.widthIn(0.dp, 488.dp).horizontalScroll(rememberScrollState()),
+                    modifier = Modifier.fillMaxWidth(),
                 )
 
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier =  Modifier.padding(top = 8.dp))  {
@@ -664,8 +664,8 @@ fun EditWordDialogPreview() {
             true,
             "Hola",
             "es",
-            "Hello",
-            "The most common and used spanish greeting",
+            "Hello, hi, hey",
+            "The most common spanish greeting used when meeting someone",
             LanguagesList(listOf("English", "Spanish", "German"), listOf("en", "es", "de")),
             true
         )

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoScreen.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoScreen.kt
@@ -101,6 +101,7 @@ fun SentenceDialog(
     languagesFrom: StringList,
     languagesTo: StringList,
     targetLangIndex: Int,
+    modifier: Modifier = Modifier,
     playIconState: MutableState<PlayIconState> = mutableStateOf(PlayIconState()),
     sourceLangIndex: Int = 0,
     detectedLanguageState: MutableIntState = mutableIntStateOf(-1),
@@ -146,8 +147,7 @@ fun SentenceDialog(
             Spacer(modifier = Modifier.weight(1f))
 
             ElevatedCard(
-                modifier = Modifier
-                    .padding(16.dp)
+                modifier = modifier
                     .onSizeChanged {
                         val sizePx = it.width.toFloat()
                         swipeableState.updateAnchors(
@@ -303,18 +303,25 @@ fun TopTextBar(
             .fillMaxWidth()
     ) {
 
-        Text(text = "From:", Modifier.padding(horizontal = 8.dp))
+        Text(
+            text = "From:",
+            Modifier.padding(horizontal = 8.dp),
+            MaterialTheme.colorScheme.onPrimary,
+        )
 
         var sourcePos by remember { mutableIntStateOf(sourceLangIndex) }
         val detectedLanguageIndex = detectedLanguageState.intValue
         val displayText = if (sourcePos == 0 && detectedLanguageIndex != -1)
             "Auto detect (${languagesTo.items.getOrNull(detectedLanguageIndex)})" else null
-        Spinner(languagesFrom, sourcePos, displayText) { index, _ ->
+        Spinner(
+            languagesFrom,
+            modifier = Modifier.weight(1f),
+            preselected = sourcePos,
+            displayText =  displayText
+        ) { index, _ ->
             onSourceLangChanged(index)
             sourcePos = index
         }
-        Spacer(Modifier.weight(1f))
-
         PlayButton(playIconState, onPlayButtonClick)
     }
 }
@@ -350,8 +357,12 @@ fun BottomTextBar(languagesTo: StringList, langIndex: Int, onTargetLangChanged: 
             .background(MaterialTheme.colorScheme.primary)
             .fillMaxWidth()
     ) {
-        Text(text = "To:", Modifier.padding(horizontal = 8.dp))
-        Spinner(languagesTo, langIndex) { index, _ ->
+        Text(
+            text = "To:",
+            Modifier.padding(horizontal = 8.dp),
+            MaterialTheme.colorScheme.onPrimary,
+        )
+        Spinner(languagesTo, Modifier.weight(1f), langIndex) { index, _ ->
             onTargetLangChanged(index)
         }
     }
@@ -376,17 +387,16 @@ fun LanguageBar(
                 .background(MaterialTheme.colorScheme.primary)
                 .weight(1f)
         ) {
-            Text(text = "From:", Modifier.padding(horizontal = 8.dp))
+            Text(text = "From:", Modifier.padding(horizontal = 8.dp), MaterialTheme.colorScheme.onPrimary)
 
             var sourcePos by remember { mutableIntStateOf(sourceLangIndex) }
             val detectedLanguageIndex = detectedLanguageState.intValue
             val displayText = if (sourcePos == 0 && detectedLanguageIndex != -1)
                 "Auto detect (${languagesTo.items.getOrNull(detectedLanguageIndex)})" else null
-            Spinner(languagesFrom, sourcePos, displayText) { index, _ ->
+            Spinner(languagesFrom, Modifier.weight(1f), sourcePos, displayText) { index, _ ->
                 onSourceLangChanged(index)
                 sourcePos = index
             }
-            Spacer(Modifier.weight(1f))
 
             PlayButton(playIconState, onPlayButtonClick)
         }
@@ -399,8 +409,8 @@ fun LanguageBar(
                 .background(MaterialTheme.colorScheme.primary)
                 .weight(1f)
         ) {
-            Text(text = "To:", Modifier.padding(horizontal = 8.dp))
-            Spinner(languagesTo, targetLangIndex) { index, _ ->
+            Text(text = "To:", Modifier.padding(horizontal = 8.dp), MaterialTheme.colorScheme.onPrimary)
+            Spinner(languagesTo, Modifier.weight(1f), targetLangIndex) { index, _ ->
                 onTargetLangChanged(index)
             }
         }
@@ -428,6 +438,7 @@ fun PlayButton(playIconState: MutableState<PlayIconState>, onPlayButtonClick: ()
             Icon(
                 painter = painterResource(iconRes),
                 contentDescription = stringResource(R.string.play_tts_icon_description),
+                tint = MaterialTheme.colorScheme.onPrimary,
             )
         }
     }

--- a/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoScreen.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/textprocessing/TextInfoScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.anchoredDraggable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -175,10 +176,10 @@ fun SentenceDialog(
                 elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
             ) {
                 Column {
+                    WordRow(wordState, onBookmarkClicked, onMoreInfoClicked)
+
                     val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
                     if (windowSizeClass.windowHeightSizeClass == WindowHeightSizeClass.COMPACT) {
-                        WordRow(wordState, onBookmarkClicked, onMoreInfoClicked)
-
                         LanguageBar(
                             languagesFrom, languagesTo, sourceLangIndex, targetLangIndex, detectedLanguageState,
                             playIconState, onPlayButtonClick, onSourceLangChanged, onTargetLangChanged
@@ -190,8 +191,6 @@ fun SentenceDialog(
 
                         BottomText(translation, highlightedSpanState, onBottomTextClick)
                     } else {
-                        WordRow(wordState, onBookmarkClicked, onMoreInfoClicked)
-
                         TopText(text, wordState, highlightedSpanState, onTopTextClick)
 
                         TopTextBar(
@@ -229,10 +228,13 @@ fun WordRow(
     if (state != null) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)
         ) {
-            Text(state.word.definition, Modifier.padding(horizontal = 8.dp))
-            Spacer(Modifier.weight(1f))
+            Text(
+                state.word.definition,
+                modifier = Modifier.weight(1f).horizontalScroll(rememberScrollState()),
+                softWrap = false,
+            )
             IconButton(onClick = onBookmarkClicked) {
                 val iconRes = if(state.isSaved) R.drawable.ic_bookmark_black_24dp else R.drawable.ic_bookmark_border_black_24dp
                 Icon(
@@ -471,7 +473,7 @@ fun EditWordDialog(
 
     Dialog(onDismissRequest = onDismiss) {
         Surface(Modifier.testTag(EDIT_WORD_DIALOG_TAG)) {
-            Column(Modifier.padding(16.dp)) {
+            Column(Modifier.padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
                 val focusManager = LocalFocusManager.current
 
                 TextField(
@@ -483,13 +485,13 @@ fun EditWordDialog(
                         onNext = { focusManager.moveFocus(FocusDirection.Down) }
                     ),
                     modifier = Modifier
-                        .fillMaxWidth()
+                        .widthIn(0.dp, 488.dp)
                         .padding(bottom = 16.dp)
                 )
                 ExposedDropdownMenuBox(
                     expanded = expanded,
                     onExpandedChange = { expanded = !expanded },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.widthIn(0.dp, 488.dp)
                 ) {
                     val lang = languages.fullNames.getOrNull(indexLang) ?: ""
                     TextField(
@@ -502,7 +504,7 @@ fun EditWordDialog(
                         keyboardActions = KeyboardActions(
                             onNext = { focusManager.moveFocus(FocusDirection.Down) }
                         ),
-                        modifier = Modifier.menuAnchor(PrimaryNotEditable).fillMaxWidth()
+                        modifier = Modifier.menuAnchor(PrimaryNotEditable).widthIn(0.dp, 488.dp)
                     )
                     ExposedDropdownMenu(
                         expanded = expanded,
@@ -529,7 +531,7 @@ fun EditWordDialog(
                     keyboardActions = KeyboardActions(
                         onNext = { focusManager.moveFocus(FocusDirection.Down) }
                     ),
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.widthIn(0.dp, 488.dp)
                 )
 
                 TextField(
@@ -537,7 +539,7 @@ fun EditWordDialog(
                     onValueChange = { notesText = it },
                     label = { Text(stringResource(id = R.string.notes_edit_text)) },
                     singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.widthIn(0.dp, 488.dp)
                 )
 
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier =  Modifier.padding(top = 8.dp))  {

--- a/app/src/main/java/com/guillermonegrete/tts/ui/theme/Color.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/ui/theme/Color.kt
@@ -3,7 +3,7 @@ package com.guillermonegrete.tts.ui.theme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 
-val GreenLight = Color(0xFF28C7BB)
+val GreenLight = Color(0xFF006a63)
 val GreenDark = Color(0xFF00968b)
 val BlueLight = Color(0xFF6a98ba)
 

--- a/app/src/main/java/com/guillermonegrete/tts/ui/theme/Theme.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/ui/theme/Theme.kt
@@ -9,9 +9,9 @@ import androidx.compose.ui.graphics.Color
 import com.guillermonegrete.tts.ui.BrightnessTheme
 
 private val DarkColorPalette = darkColorScheme(
-    primary = GreenLight,
-    onPrimary = Color.White,
-    secondary = GreenDark,
+    primary = Color(0xFF81d5cc),
+    onPrimary = Color(0xFF003733),
+    secondary = GreenLight,
     tertiary = BlueLight,
 )
 

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderScreen.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderScreen.kt
@@ -113,7 +113,7 @@ fun WebReaderBottomBar(
 
         Spacer(Modifier.weight(1f))
 
-        Spinner(languages, langSelection.value, onItemSelected = onLangSelected)
+        Spinner(languages, preselected = langSelection.value, onItemSelected = onLangSelected)
 
         WebReaderBarMenu(isPageSaved, wordsShown, getPageVersion, false, onMenuItemClick)
     }

--- a/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderScreen.kt
+++ b/app/src/main/java/com/guillermonegrete/tts/webreader/WebReaderScreen.kt
@@ -39,9 +39,12 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -77,7 +80,7 @@ fun WebReaderBottomBar(
         modifier = Modifier
             .testTag("web_reader_bar")
             .height(WebReaderBarHeight),
-        contentPadding = PaddingValues(vertical = 8.dp), // Default is 12dp but it causes asymmetry with height 64 dp
+        contentPadding = PaddingValues(vertical = 8.dp), // Default is 12dp which causes asymmetry with height 64 dp
         windowInsets = WindowInsets(0, 0, 0, 0), // The default insets take too much space when E2E, the insets are handled in the parent view of this bar
     ) {
         IconButton(
@@ -156,8 +159,6 @@ fun WebReaderBarMenu(
                     Icon(painter = painterResource(icon), contentDescription = if (isSaved) "Delete" else "Save")
                 },
             )
-
-            Spacer(modifier = Modifier.height(8.dp))
 
             if (isSaved) {
                 DropdownMenuItem(
@@ -436,7 +437,8 @@ fun CircleColorButton(color: Color, index: Int, colorSel: MutableIntState) {
         .padding(3.dp) // margin
         .border(3.dp, color, shape = CircleShape)
         .padding(6.dp) // space between circle and ring, real size is this value minus the border size. 6dp - 3dp = 3dp
-        .size(36.dp) else Modifier
+        .size(36.dp)
+    else Modifier
         .padding(12.dp)
         .size(36.dp)
 
@@ -444,9 +446,11 @@ fun CircleColorButton(color: Color, index: Int, colorSel: MutableIntState) {
     Box(Modifier.size(48.dp)) {
         OutlinedButton(
             onClick = { colorSel.intValue = index },
-            modifier = modifier.testTag(index.toString()),
+            modifier = modifier.semantics{
+                contentDescription = color.toString()
+            }.testTag(index.toString()),
             shape = CircleShape,
-            colors = ButtonDefaults.buttonColors(containerColor = color)
+            colors = ButtonDefaults.buttonColors(containerColor = color),
         ) {}
     }
 }
@@ -470,9 +474,9 @@ fun MultiToggleButton(
             .border(BorderStroke(1.dp, Color.LightGray))
     ) {
         toggleStates.items.forEachIndexed { index, toggleState ->
-            val isSelected = currentSelection.lowercase() == toggleState.lowercase()
+            val isSelected = currentSelection.equals(toggleState, ignoreCase = true)
             val backgroundTint = if (isSelected) selectedTint else unselectedTint
-            val textColor = if (isSelected) Color.White else Color.Unspecified
+            val textColor = if (isSelected) MaterialTheme.colorScheme.onPrimary else Color.Unspecified
 
             if (index != 0) {
                 VerticalDivider(
@@ -518,7 +522,7 @@ fun BarPreview() {
 fun WebReaderBarMenuPreview() {
     AppTheme {
         Surface {
-            WebReaderBarMenu(remember { mutableStateOf(false) }, true, { "Local" }, true) { }
+            WebReaderBarMenu(remember { mutableStateOf(true) }, true, { "Local" }, true) { }
         }
     }
 }
@@ -539,19 +543,12 @@ fun DeletePageDialogPreview() {
     }
 }
 
-@Preview
+@PreviewScreenSizes
 @Composable
 fun AddNoteDialogPreview() {
     AppTheme {
-        AddNoteDialog(true, "", 0, true)
-    }
-}
-
-@Preview
-@Composable
-fun AddNoteDialogMediumPreview() {
-    AppTheme {
-        AddNoteDialogMedium(true, "", 0, true)
+        val state = AddNoteDialogUI("", 0, true)
+        AddNoteDialog(state)
     }
 }
 

--- a/app/src/main/res/values-night/color.xml
+++ b/app/src/main/res/values-night/color.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="md_theme_primary">#81d5cc</color>
+    <color name="md_theme_onPrimary">#003733</color>
     <color name="list_bg_variant">#252525</color>
 </resources>

--- a/app/src/main/res/values/color.xml
+++ b/app/src/main/res/values/color.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!--This colors were obtained using the Material Theme Builder: https://material-foundation.github.io/material-theme-builder/
+    <!--These colors were obtained using the Material Theme Builder: https://material-foundation.github.io/material-theme-builder/
     Set the source color as #28C7BB, leave "Stay true to my color inputs" unchecked so the tool generates the secondary, tertiary and other colors for you.
     Then set the primary color as #28C7BB, check "Stay true to my color inputs" and copy the other 3 primary colors (onPrimary, etc...).-->
-    <color name="md_theme_primary">#28C7BB</color>
+    <color name="md_theme_primary">#006a63</color>
     <color name="md_theme_onPrimary">#FFFFFF</color>
     <color name="md_theme_primaryContainer">#3ad2c5</color>
     <color name="md_theme_onPrimaryContainer">#003632</color>


### PR DESCRIPTION
Closes #307.

The UI Check showed some false positive errors:

- When using `ExposedDropdownMenuBox` and `TextField` and the modifier `menuAnchor(PrimaryNotEditable)`, you get the error: TextView is covered by Spinner.
- If the text length of a `TextField` is too short in the Desktop configuration, you get the error: Insufficient text color contrast ratio.
- When you have an `IconButton` at the end of a Composable centered horizontally, you get the error: Composable is partially hidden in layout
- If the text length of a `Text` is too short in the 180% font scale configuration, you get the error: Insufficient text color contrast ratio.

